### PR TITLE
O11Y-990: Set span status

### DIFF
--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -1,3 +1,5 @@
+import 'package:opentelemetry/src/api/trace/span_status.dart';
+
 import 'span_context.dart';
 
 /// A representation of a single operation within a trace.
@@ -19,7 +21,19 @@ abstract class Span {
 
   /// Get the time when the span was started.
   int get startTime;
-  
+
+  /// Sets the status to the [Span].
+  ///
+  /// If used, this will override the default [Span] status. Default status code
+  /// is [StatusCode.UNSET].
+  ///
+  /// Only the value of the last call will be recorded, and implementations are
+  /// free to ignore previous calls.
+  void setStatus(StatusCode status, {String description});
+
+  /// Retrieve the status of the [Span].
+  SpanStatus get status;
+
   /// Marks the end of this span's execution.
   void end();
 }

--- a/lib/src/api/trace/span_status.dart
+++ b/lib/src/api/trace/span_status.dart
@@ -1,0 +1,18 @@
+/// The set of canonical status codes.
+enum StatusCode {
+  /// The default status.
+  UNSET,
+
+  /// The operation contains an error.
+  ERROR,
+
+  /// The operation has been validated by an Application developers or
+  /// Operator to have completed successfully.
+  OK,
+}
+
+/// A representation of the status of a Span.
+class SpanStatus {
+  StatusCode code = StatusCode.UNSET;
+  String description;
+}

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -1,28 +1,27 @@
-import '../../../src/api/trace/span.dart' as span_api;
-import '../../../src/api/trace/span_context.dart';
+import 'package:opentelemetry/src/api/trace/span.dart' as span_api;
+import 'package:opentelemetry/src/api/trace/span_context.dart';
+import 'package:opentelemetry/src/api/trace/span_status.dart';
 
 /// A representation of a single operation within a trace.
 class Span implements span_api.Span {
+  int _startTime;
   int _endTime;
   final String _name;
   final String _parentSpanId;
   final SpanContext _spanContext;
-  int _startTime;
+  final SpanStatus _status = SpanStatus();
 
   /// Construct a [Span].
-  Span(
-    this._name, 
-    this._spanContext, 
-    this._parentSpanId
-  ) {
+  Span(this._name, this._spanContext, this._parentSpanId) {
     _startTime = DateTime.now().toUtc().microsecondsSinceEpoch;
-    print('--- $_name START $_startTime ---\ntraceId: ${_spanContext.traceId}\nparent: $_parentSpanId\nspanId: ${_spanContext.spanId}');
+    print(
+        '--- $_name START $_startTime ---\ntraceId: ${_spanContext.traceId}\nparent: $_parentSpanId\nspanId: ${_spanContext.spanId}');
   }
 
   @override
   SpanContext get spanContext => _spanContext;
 
-    @override
+  @override
   int get endTime => _endTime;
 
   @override
@@ -31,6 +30,26 @@ class Span implements span_api.Span {
   @override
   void end() {
     _endTime = DateTime.now().toUtc().microsecondsSinceEpoch;
-    print('--- $_name END $_endTime ---\ntraceId: ${_spanContext.traceId}\nparent: $_parentSpanId\nspanId: ${_spanContext.spanId}');
+    print(
+        '--- $_name END $_endTime ---\ntraceId: ${_spanContext.traceId}\nparent: $_parentSpanId\nspanId: ${_spanContext.spanId}');
   }
+
+  @override
+  void setStatus(StatusCode status, {String description}) {
+    // A status cannot be Unset after being set, and cannot be set to any other
+    // status after being marked "Ok".
+    if (status == StatusCode.UNSET || _status.code == StatusCode.OK) {
+      return;
+    }
+
+    _status.code = status;
+
+    // Description is ignored for statuses other than "Error".
+    if (status == StatusCode.ERROR && description != null) {
+      _status.description = description;
+    }
+  }
+
+  @override
+  SpanStatus get status => _status;
 }

--- a/test/integration/sdk/span_test.dart
+++ b/test/integration/sdk/span_test.dart
@@ -1,3 +1,4 @@
+import 'package:opentelemetry/src/api/trace/span_status.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_context.dart';
 import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
@@ -5,7 +6,8 @@ import 'package:test/test.dart';
 
 void main() {
   test('span set and end time', () {
-    final span = Span('foo', SpanContext('trace123', '789', TraceState()), 'span456');
+    final span =
+        Span('foo', SpanContext('trace123', '789', TraceState()), 'span456');
 
     expect(span.startTime, isA<int>());
     expect(span.endTime, isNull);
@@ -14,5 +16,42 @@ void main() {
     expect(span.startTime, isA<int>());
     expect(span.endTime, isA<int>());
     expect(span.endTime, greaterThan(span.startTime));
+  });
+
+  test('span status', () {
+    final span =
+        Span('foo', SpanContext('trace123', '789', TraceState()), 'span456');
+
+    // Verify span status' defaults.
+    expect(span.status.code, equals(StatusCode.UNSET));
+    expect(span.status.description, equals(null));
+
+    // Verify that span status can be set to "Error".
+    span.setStatus(StatusCode.ERROR, description: 'Something s\'ploded.');
+    expect(span.status.code, equals(StatusCode.ERROR));
+    expect(span.status.description, equals('Something s\'ploded.'));
+
+    // Verify that multiple errors update the span to the most recently set.
+    span.setStatus(StatusCode.ERROR, description: 'Another error happened.');
+    expect(span.status.code, equals(StatusCode.ERROR));
+    expect(span.status.description, equals('Another error happened.'));
+
+    // Verify that span status cannot be set to "Unset" and that description
+    // is ignored for statuses other than "Error".
+    span.setStatus(StatusCode.UNSET,
+        description: 'Oops.  Can we turn this back off?');
+    expect(span.status.code, equals(StatusCode.ERROR));
+    expect(span.status.description, equals('Another error happened.'));
+
+    // Verify that span status can be set to "Ok" and that description is
+    // ignored for statuses other than "Error".
+    span.setStatus(StatusCode.OK, description: 'All done here.');
+    expect(span.status.code, equals(StatusCode.OK));
+    expect(span.status.description, equals('Another error happened.'));
+
+    // Verify that span status cannot be changed once set to "Ok".
+    span.setStatus(StatusCode.ERROR, description: 'Something else went wrong.');
+    expect(span.status.code, equals(StatusCode.OK));
+    expect(span.status.description, equals('Another error happened.'));
   });
 }


### PR DESCRIPTION
## Notes

This PR adds the ability to set the status of a span.

The OpenTelemetry Spec outlines the following restrictions for span status, see [the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status) for more information.

## Reviewers
@tylersnavely-wf 
@Workiva/product-new-relic 
