### PR TITLE
Fix release validation errors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+Copyright 2021 Workiva Inc. All rights reserved.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,13 @@
 name: opentelemetry
-version: 0.0.1
+version: 0.0.2
+description: A framework for collecting traces from applications.
+homepage: https://github.com/Workiva/opentelemetry-dart
+publish_to: https://pub.workiva.org
 environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
+  fixnum: ^0.10.0
   http: ^0.12.0
   logging: ^0.11.0
   protobuf: ^1.1.0


### PR DESCRIPTION
The release failed because of the following errors:
```
Publishing opentelemetry 0.0.1 to https://pub.workiva.org:
|-- README.md
|-- analysis_options.yaml
|-- lib
|   |-- api.dart
|   |-- sdk.dart
|   '-- src
|       |-- api
|       |   |-- context
|       |   |   '-- context.dart
|       |   '-- trace
|       |       |-- context_utils.dart
|       |       |-- id_generator.dart
|       |       |-- span.dart
|       |       |-- span_context... (8280 more, please see e.stdout)
STDERR:
Missing requirements:
* You must have a COPYING, LICENSE or UNLICENSE file in the root directory.
An open-source license helps ensure people can legally use your code.
* Your pubspec.yaml is missing a "description" field.
* Your pubspec.yaml is missing a "homepage" field.
Suggestions:
* line 1, column 1 of lib/src/api/trace/span.dart: This package does not have fixnum in the `dependencies` section of `pubspec.yaml`.
╷
1 │ import 'package:fixnum/fixnum.dart';
│ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
╵
* line 1, column 1 of lib/src/sdk/trace/span.dart: This package does not have fixnum in the `dependencies` section of `pubspec.yaml`.
╷
1 │ import 'package:fixnum/fixnum.dart';
│ ^^^^^^^^^^^^^^^^^^^^^^^^^^^... (163 more, please see e.stderr)
Pub artifact upload failed for /artifacts/pub/build/pub_package.pub.tgz
```