### PR TITLE
O11Y-1019: Inject and Extract context from a message to feed into span creation

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -1,11 +1,17 @@
 export 'src/api/common/attribute.dart' show Attribute;
 export 'src/api/common/attributes.dart' show Attributes;
 export 'src/api/context/context.dart' show Context;
+export 'src/api/propagation/extractors/text_map_getter.dart' show TextMapGetter;
+export 'src/api/propagation/injectors/text_map_setter.dart' show TextMapSetter;
+export 'src/api/propagation/text_map_propagator.dart' show TextMapPropagator;
 export 'src/api/trace/context_utils.dart'
     show getSpan, getSpanContext, setSpan, withContext;
 export 'src/api/trace/id_generator.dart' show IdGenerator;
 export 'src/api/trace/span.dart' show Span;
 export 'src/api/trace/span_context.dart' show SpanContext;
+export 'src/api/trace/span_id.dart' show SpanId;
+export 'src/api/trace/trace_flags.dart' show TraceFlags;
+export 'src/api/trace/trace_id.dart' show TraceId;
 export 'src/api/trace/trace_state.dart' show TraceState;
 export 'src/api/trace/tracer.dart' show Tracer;
 export 'src/api/trace/tracer_provider.dart' show TracerProvider;

--- a/lib/src/api/propagation/extractors/text_map_getter.dart
+++ b/lib/src/api/propagation/extractors/text_map_getter.dart
@@ -1,0 +1,10 @@
+import '../text_map_propagator.dart';
+
+/// Interface that allows a [TextMapPropagator] to read propagated fields from a carrier.
+abstract class TextMapGetter<C> {
+  /// Returns all the keys in the given carrier.
+  Iterable<String> keys(C carrier);
+
+  /// Returns the first value of the given propagation [key] or returns null.
+  String get(C carrier, String key);
+}

--- a/lib/src/api/propagation/injectors/text_map_setter.dart
+++ b/lib/src/api/propagation/injectors/text_map_setter.dart
@@ -1,0 +1,7 @@
+import '../text_map_propagator.dart';
+
+/// Class that allows a [TextMapPropagator] to set propagated fields into a carrier.
+abstract class TextMapSetter<C> {
+  /// Sets [value] for [key] on [carrier].
+  void set(C carrier, String key, String value);
+}

--- a/lib/src/api/propagation/text_map_propagator.dart
+++ b/lib/src/api/propagation/text_map_propagator.dart
@@ -1,0 +1,15 @@
+import '../context/context.dart';
+import 'extractors/text_map_getter.dart';
+import 'injectors/text_map_setter.dart';
+
+/// A class responsible for performing the injection and extraction of a
+/// cross-cutting concern value as string key/values pairs into carriers that
+/// travel across process boundaries.
+///
+/// See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#textmap-propagator
+/// for full specification.
+abstract class TextMapPropagator<C> {
+  void inject(Context context, C carrier, TextMapSetter<C> setter);
+
+  Context extract(Context context, C carrier, TextMapGetter<C> getter);
+}

--- a/lib/src/api/trace/nonrecording_span.dart
+++ b/lib/src/api/trace/nonrecording_span.dart
@@ -1,0 +1,68 @@
+import 'package:fixnum/fixnum.dart';
+
+import '../../sdk/common/attributes.dart' as sdk_attributes;
+import '../../sdk/trace/span.dart';
+import '../../sdk/trace/span_context.dart' as sdk_spancontext;
+import '../../sdk/trace/span_id.dart';
+import '../common/attributes.dart';
+import 'noop_tracer.dart';
+import 'span.dart' as api;
+import 'span_context.dart';
+import 'span_status.dart';
+import 'tracer.dart';
+
+/// A class representing a [Span] which should not be sampled or recorded.
+///
+/// See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#wrapping-a-spancontext-in-a-span
+/// for more information.
+///
+/// This class should not be exposed to consumers and is used internally to wrap
+/// [SpanContext] being injected or extracted for external calls.
+class NonRecordingSpan extends Span implements api.Span {
+  final Attributes _attributes = sdk_attributes.Attributes.empty();
+  final SpanStatus _status = SpanStatus()..code = StatusCode.OK;
+  final Tracer _tracer = NoopTracer();
+  final SpanContext _spanContext;
+
+  NonRecordingSpan(this._spanContext)
+      : super('NON_RECORDING', _spanContext, null, [], NoopTracer());
+
+  @override
+  Attributes get attributes => _attributes;
+
+  @override
+  set attributes(Attributes attributes) {
+    return;
+  }
+
+  @override
+  void end() {
+    return;
+  }
+
+  @override
+  Int64 get endTime => Int64.ZERO;
+
+  @override
+  String get name => 'NON_RECORDING';
+
+  @override
+  SpanId get parentSpanId => null;
+
+  @override
+  void setStatus(StatusCode status, {String description}) {
+    return;
+  }
+
+  @override
+  sdk_spancontext.SpanContext get spanContext => _spanContext;
+
+  @override
+  Int64 get startTime => Int64.ZERO;
+
+  @override
+  SpanStatus get status => _status;
+
+  @override
+  Tracer get tracer => _tracer;
+}

--- a/lib/src/api/trace/noop_tracer.dart
+++ b/lib/src/api/trace/noop_tracer.dart
@@ -1,0 +1,20 @@
+import '../../../api.dart' as api;
+import '../../sdk/trace/span_context.dart';
+import 'nonrecording_span.dart';
+import 'tracer.dart' as api;
+
+/// A [api.Tracer] class which yields [NonRecordingSpan]s and no-ops for most
+/// operations.
+class NoopTracer implements api.Tracer {
+  @override
+  String get name => 'NOOP';
+
+  @override
+  api.Span startSpan(String name,
+      {api.Context context, api.Attributes attributes}) {
+    final SpanContext parentContext = api.getSpanContext(context);
+
+    return NonRecordingSpan(
+        (parentContext.isValid) ? parentContext : SpanContext.invalid());
+  }
+}

--- a/lib/src/api/trace/sampler.dart
+++ b/lib/src/api/trace/sampler.dart
@@ -1,7 +1,7 @@
-import 'package:opentelemetry/src/api/context/context.dart';
-import 'package:opentelemetry/src/api/instrumentation_library.dart';
-import 'package:opentelemetry/src/api/trace/sampling_result.dart';
-import 'package:opentelemetry/src/api/trace/span.dart';
+import '../context/context.dart';
+import '../instrumentation_library.dart';
+import 'sampling_result.dart';
+import 'span.dart';
 
 /// Represents an entity which determines whether a [Span] should be sampled
 /// and sent for collection.

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -1,8 +1,9 @@
 import 'package:fixnum/fixnum.dart';
-import 'span_status.dart';
-import '../common/attributes.dart';
 
+import '../common/attributes.dart';
 import 'span_context.dart';
+import 'span_id.dart';
+import 'span_status.dart';
 import 'tracer.dart';
 
 /// A representation of a single operation within a trace.
@@ -26,10 +27,14 @@ abstract class Span {
   Int64 get startTime;
 
   /// The parent span id.
-  List<int> get parentSpanId;
+  SpanId get parentSpanId;
 
   /// The name of the span.
   String get name;
+
+  /// Whether this Span is recording information like events with the
+  /// addEvent operation, status with setStatus, etc.
+  bool get isRecording;
 
   /// Sets the status to the [Span].
   ///

--- a/lib/src/api/trace/span_context.dart
+++ b/lib/src/api/trace/span_context.dart
@@ -1,13 +1,22 @@
+import 'span_id.dart';
+import 'trace_flags.dart';
+import 'trace_id.dart';
 import 'trace_state.dart';
 
 /// Representation of the context of the context of an individual span.
 abstract class SpanContext {
   /// Get the ID of the span.
-  List<int> get spanId;
+  SpanId get spanId;
 
   /// Get the ID of the trace the span is a part of.
-  List<int> get traceId;
+  TraceId get traceId;
+
+  /// Get flags (sampling, trace level, etc.) set for the trace the span is a
+  /// part of.
+  TraceFlags get traceFlags;
 
   /// Get the state of the entire trace.
   TraceState get traceState;
+
+  bool get isValid;
 }

--- a/lib/src/api/trace/span_id.dart
+++ b/lib/src/api/trace/span_id.dart
@@ -1,0 +1,21 @@
+import 'span.dart';
+
+/// Class representing an ID for a single [Span].
+/// See https://www.w3.org/TR/trace-context/#parent-id for full specification.
+abstract class SpanId {
+  static const SIZE_BITS = 16;
+  static const SIZE_BYTES = 8;
+  static final List<int> INVALID =
+      List<int>.filled(SIZE_BYTES, 0); // 0000000000000000
+  static final List<int> ROOT = [];
+
+  /// Retrieve this SpanId as a list of byte values.
+  List<int> get();
+
+  /// Whether this ID represents a valid [Span].
+  bool get isValid;
+
+  /// Retrieve this SpanId as a human-readable ID.
+  @override
+  String toString();
+}

--- a/lib/src/api/trace/trace_flags.dart
+++ b/lib/src/api/trace/trace_flags.dart
@@ -1,0 +1,8 @@
+/// A class which controls tracing flags for sampling, trace level, and so forth.
+/// See https://www.w3.org/TR/trace-context/#trace-flags for full specification.
+abstract class TraceFlags {
+  static const int SIZE = 2;
+  static const int NONE = 0x00;
+  static const int SAMPLED_FLAG = 0x01;
+  static const int INVALID = 0xff;
+}

--- a/lib/src/api/trace/trace_id.dart
+++ b/lib/src/api/trace/trace_id.dart
@@ -1,0 +1,18 @@
+/// Class representing an ID for a single Trace.
+/// See https://www.w3.org/TR/trace-context/#trace-id for full specification.
+abstract class TraceId {
+  static const SIZE_BITS = 32;
+  static const SIZE_BYTES = 16;
+  static final List<int> INVALID =
+      List<int>.filled(SIZE_BYTES, 0); // 00000000000000000000000000000000
+
+  /// Retrieve this TraceId as a list of byte values.
+  List<int> get();
+
+  /// Whether this ID represents a valid Trace.
+  bool get isValid;
+
+  /// Retrieve this SpanId as a human-readable ID.
+  @override
+  String toString();
+}

--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -1,2 +1,26 @@
 /// Representation of the state of a trace.
-abstract class TraceState {}
+abstract class TraceState {
+  /// Retrieve a value from the TraceState for a given key.
+  String get(String key);
+
+  /// Adds a key value pairs to the TraceState.
+  ///
+  /// Key is an opaque string up to 256 characters printable. It MUST begin
+  /// with a lowercase letter, and can only contain lowercase letters a-z,
+  /// digits 0-9, underscores _, dashes -, asterisks *, and forward slashes /.
+  /// For multi-tenant vendor scenarios, an at sign (@) can be used to prefix
+  /// the vendor name. The tenant id (before the '@') is limited to 240
+  /// characters and the vendor id is limited to 13 characters. If in the
+  /// multi-tenant vendor format, then the first character may additionally
+  /// be numeric.
+  ///
+  /// Value is opaque string up to 256 characters printable ASCII RFC0020
+  /// characters (i.e., the range 0x20 to 0x7E) except comma , and =.
+  void put(String key, String value);
+
+  /// The number of key/value pairs contained in this TraceState.
+  int get size;
+
+  /// Whether this TraceState is emtpy.
+  bool get isEmpty;
+}

--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -1,6 +1,5 @@
-import '../common/attributes.dart';
-
 import '../../../src/api/context/context.dart';
+import '../common/attributes.dart';
 import 'span.dart';
 
 /// An interface for creating [Span]s and propagating context in-process.

--- a/lib/src/sdk/trace/exporters/collector_exporter.dart
+++ b/lib/src/sdk/trace/exporters/collector_exporter.dart
@@ -66,9 +66,9 @@ class CollectorExporter implements SpanExporter {
     }
 
     return pb.Span(
-        traceId: span.spanContext.traceId,
-        spanId: span.spanContext.spanId,
-        parentSpanId: span.parentSpanId,
+        traceId: span.spanContext.traceId.get(),
+        spanId: span.spanContext.spanId.get(),
+        parentSpanId: span.parentSpanId?.get(),
         name: span.name,
         startTimeUnixNano: span.startTime * 1000,
         endTimeUnixNano: span.endTime * 1000,

--- a/lib/src/sdk/trace/exporters/console_exporter.dart
+++ b/lib/src/sdk/trace/exporters/console_exporter.dart
@@ -9,16 +9,10 @@ class ConsoleExporter implements SpanExporter {
     for (var i = 0; i < spans.length; i++) {
       final span = spans[i];
       print({
-        'traceId': span.spanContext.traceId
-            .map((x) => x.toRadixString(16).padLeft(2, '0'))
-            .join(),
-        'parentId': span.parentSpanId
-            .map((x) => x.toRadixString(16).padLeft(2, '0'))
-            .join(),
+        'traceId': span.spanContext.traceId.toString(),
+        'parentId': span.parentSpanId?.toString(),
         'name': span.name,
-        'id': span.spanContext.spanId
-            .map((x) => x.toRadixString(16).padLeft(2, '0'))
-            .join(),
+        'id': span.spanContext.spanId.toString(),
         'timestamp': span.startTime,
         'duration': span.endTime - span.startTime,
         'status': span.status.code

--- a/lib/src/sdk/trace/propagation/extractors/fcontext_extractor.dart
+++ b/lib/src/sdk/trace/propagation/extractors/fcontext_extractor.dart
@@ -1,0 +1,15 @@
+import 'package:frugal/frugal.dart';
+import '../../../../api/propagation/extractors/text_map_getter.dart';
+
+class FContextExtractor implements TextMapGetter<FContext> {
+  @override
+  String get(FContext carrier, String key) {
+    return (carrier == null) ? null : carrier.requestHeader(key);
+  }
+
+  @override
+  Iterable<String> keys(FContext carrier) {
+    final map = carrier.requestHeaders();
+    return map.keys;
+  }
+}

--- a/lib/src/sdk/trace/propagation/injectors/fcontext_injector.dart
+++ b/lib/src/sdk/trace/propagation/injectors/fcontext_injector.dart
@@ -1,0 +1,11 @@
+import 'package:frugal/frugal.dart' show FContext;
+import '../../../../api/propagation/injectors/text_map_setter.dart';
+
+class FContextInjector implements TextMapSetter<FContext> {
+  @override
+  void set(FContext carrier, String key, String value) {
+    if (carrier != null) {
+      carrier.addRequestHeader(key, value);
+    }
+  }
+}

--- a/lib/src/sdk/trace/propagation/w3c_trace_context_propagator.dart
+++ b/lib/src/sdk/trace/propagation/w3c_trace_context_propagator.dart
@@ -1,0 +1,71 @@
+import '../../../../api.dart' as api;
+import '../../../api/trace/context_utils.dart';
+import '../../../api/trace/nonrecording_span.dart';
+import '../span_context.dart';
+import '../span_id.dart';
+import '../trace_flags.dart';
+import '../trace_id.dart';
+import '../trace_state.dart';
+
+class W3CTraceContextPropagator implements api.TextMapPropagator {
+  static const String _TRACE_VERSION = '00';
+  static const String _TRACE_PARENT_HEADER_KEY = 'traceparent';
+  static const String _TRACE_STATE_HEADER_KEY = 'tracestate';
+  // See https://www.w3.org/TR/trace-context/#traceparent-header-field-values
+  // for trace parent header specification.
+  static final RegExp traceParentHeaderRegEx =
+      RegExp('^(?<version>[0-9a-f]{2})-'
+          '(?<traceid>[0-9a-f]{${api.TraceId.SIZE_BITS}})-'
+          '(?<parentid>[0-9a-f]{${api.SpanId.SIZE_BITS}})-'
+          '(?<traceflags>[0-9a-f]{${api.TraceFlags.SIZE}})\$');
+
+  @override
+  api.Context extract(
+      api.Context context, dynamic carrier, api.TextMapGetter getter) {
+    final traceParentHeader = getter.get(carrier, _TRACE_PARENT_HEADER_KEY);
+    if (traceParentHeader == null) {
+      // Carrier did not contain a trace header.  Do nothing.
+      return context;
+    }
+    if (!traceParentHeaderRegEx.hasMatch(traceParentHeader)) {
+      // Encountered a malformed or unknown trace header.  Do nothing.
+      return context;
+    }
+
+    final parentHeaderMatch =
+        traceParentHeaderRegEx.firstMatch(traceParentHeader);
+    final parentHeaderFields = Map<String, String>.fromIterable(
+        parentHeaderMatch.groupNames,
+        key: (element) => element.toString(),
+        value: (element) => parentHeaderMatch.namedGroup(element));
+
+    final TraceId traceId = TraceId.fromString(parentHeaderFields['traceid']) ??
+        api.TraceId.INVALID;
+    final SpanId parentId =
+        SpanId.fromString(parentHeaderFields['parentid']) ?? api.SpanId.INVALID;
+    final TraceFlags traceFlags =
+        TraceFlags.fromString(parentHeaderFields['traceflags']) ??
+            api.TraceFlags.NONE;
+
+    final traceStateHeader = getter.get(carrier, _TRACE_STATE_HEADER_KEY);
+    final traceState = (traceStateHeader != null)
+        ? TraceState.fromString(traceStateHeader)
+        : TraceState.empty();
+
+    return setSpan(
+        context,
+        NonRecordingSpan(
+            SpanContext(traceId, parentId, traceFlags, traceState)));
+  }
+
+  @override
+  void inject(api.Context context, dynamic carrier, api.TextMapSetter setter) {
+    final SpanContext spanContext = api.getSpanContext(context);
+
+    setter
+      ..set(carrier, _TRACE_PARENT_HEADER_KEY,
+          '$_TRACE_VERSION-${spanContext.traceId.toString()}-${spanContext.spanId.toString()}-${spanContext.traceFlags.toString()}')
+      ..set(
+          carrier, _TRACE_STATE_HEADER_KEY, spanContext.traceState.toString());
+  }
+}

--- a/lib/src/sdk/trace/span_context.dart
+++ b/lib/src/sdk/trace/span_context.dart
@@ -1,21 +1,34 @@
-import '../../../src/api/trace/span_context.dart' as span_context_api;
-import '../../../src/api/trace/trace_state.dart';
+import '../../../api.dart' as api;
+import 'span_id.dart';
+import 'trace_flags.dart';
+import 'trace_id.dart';
+import 'trace_state.dart';
 
 /// Representation of the context of the context of an individual span.
-class SpanContext implements span_context_api.SpanContext {
-  final List<int> _spanId;
-  final List<int> _traceId;
+class SpanContext implements api.SpanContext {
+  final SpanId _spanId;
+  final TraceId _traceId;
+  final TraceFlags _traceFlags;
   final TraceState _traceState;
 
   @override
-  List<int> get spanId => _spanId;
+  TraceId get traceId => _traceId;
 
   @override
-  List<int> get traceId => _traceId;
+  SpanId get spanId => _spanId;
+
+  @override
+  TraceFlags get traceFlags => _traceFlags;
 
   @override
   TraceState get traceState => _traceState;
 
+  @override
+  bool get isValid => spanId.isValid && traceId.isValid;
+
   /// Construct a [SpanContext].
-  SpanContext(this._traceId, this._spanId, this._traceState);
+  SpanContext(this._traceId, this._spanId, this._traceFlags, this._traceState);
+
+  factory SpanContext.invalid() => SpanContext(TraceId.invalid(),
+      SpanId.invalid(), TraceFlags.invalid(), TraceState.empty());
 }

--- a/lib/src/sdk/trace/span_id.dart
+++ b/lib/src/sdk/trace/span_id.dart
@@ -1,0 +1,30 @@
+import '../../../api.dart' as api;
+
+class SpanId implements api.SpanId {
+  List<int> _id;
+
+  SpanId(this._id);
+  SpanId.fromIdGenerator(api.IdGenerator generator) {
+    _id = generator.generateSpanId();
+  }
+  SpanId.fromString(String id) {
+    _id = [];
+    id = id.padLeft(api.SpanId.SIZE_BITS, '0');
+
+    for (var i = 0; i < id.length; i += 2) {
+      _id.add(int.parse('${id[i]}${id[i + 1]}', radix: 16));
+    }
+  }
+  factory SpanId.invalid() => SpanId(api.SpanId.INVALID);
+  factory SpanId.root() => SpanId(api.SpanId.ROOT);
+
+  @override
+  List<int> get() => _id;
+
+  @override
+  bool get isValid => _id.join() != api.SpanId.INVALID.join();
+
+  @override
+  String toString() =>
+      _id.map((x) => x.toRadixString(16).padLeft(2, '0')).join();
+}

--- a/lib/src/sdk/trace/trace_flags.dart
+++ b/lib/src/sdk/trace/trace_flags.dart
@@ -1,0 +1,34 @@
+import '../../api/trace/trace_flags.dart' as api;
+
+class TraceFlags implements api.TraceFlags {
+  int _flags = api.TraceFlags.NONE;
+
+  TraceFlags(this._flags);
+  TraceFlags.fromString(String traceFlags) {
+    traceFlags = traceFlags.padLeft(api.TraceFlags.SIZE, '0');
+
+    for (var i = 0; i < traceFlags.length; i += 2) {
+      _flags = int.parse('${traceFlags[i]}${traceFlags[i + 1]}', radix: 16);
+    }
+  }
+  factory TraceFlags.invalid() => TraceFlags(api.TraceFlags.INVALID);
+
+  @override
+  String toString() {
+    return _flags.toRadixString(16).padLeft(2, '0');
+  }
+
+  set sampled(bool sampled) {
+    if (sampled) {
+      _flags |= api.TraceFlags.SAMPLED_FLAG;
+    } else {
+      _flags &= ~api.TraceFlags.SAMPLED_FLAG;
+    }
+  }
+
+  bool get sampled =>
+      isValid &&
+      ((_flags & api.TraceFlags.SAMPLED_FLAG) == api.TraceFlags.SAMPLED_FLAG);
+
+  bool get isValid => _flags != api.TraceFlags.INVALID;
+}

--- a/lib/src/sdk/trace/trace_id.dart
+++ b/lib/src/sdk/trace/trace_id.dart
@@ -1,0 +1,29 @@
+import '../../../api.dart' as api;
+
+class TraceId implements api.TraceId {
+  List<int> _id;
+
+  TraceId(this._id);
+  TraceId.fromIdGenerator(api.IdGenerator generator) {
+    _id = generator.generateTraceId();
+  }
+  TraceId.fromString(String id) {
+    _id = [];
+    id = id.padLeft(api.TraceId.SIZE_BITS, '0');
+
+    for (var i = 0; i < id.length; i += 2) {
+      _id.add(int.parse('${id[i]}${id[i + 1]}', radix: 16));
+    }
+  }
+  factory TraceId.invalid() => TraceId(api.TraceId.INVALID);
+
+  @override
+  List<int> get() => _id;
+
+  @override
+  bool get isValid => _id.join() != api.TraceId.INVALID.join();
+
+  @override
+  String toString() =>
+      _id.map((x) => x.toRadixString(16).padLeft(2, '0')).join();
+}

--- a/lib/src/sdk/trace/trace_state.dart
+++ b/lib/src/sdk/trace/trace_state.dart
@@ -1,4 +1,118 @@
 import '../../../src/api/trace/trace_state.dart' as api;
 
 /// Representation of the state of a trace.
-class TraceState implements api.TraceState {}
+///
+/// See W3C documentation: https://www.w3.org/TR/trace-context/#tracestate-header
+class TraceState implements api.TraceState {
+  static const int _MAX_KEY_VALUE_PAIRS = 32;
+  static const int _KEY_MAX_SIZE = 256;
+  static const int _VALUE_MAX_SIZE = 256;
+  static final RegExp validKeyRegex = RegExp(
+      r'^[a-z][\w\-\*\/]{0,255}$|^[a-z0-9][\w\-\*\/]{0,239}\@[\w\-\*\/]{0,13}$');
+  static final RegExp validValueRegex = RegExp(
+      r'^[\w\"\@\#\$\%\^\&\*\(\)\+\-\.\/\:\;\<\>\?\[\]\\\`\{\|\}]{1,256}$');
+  final Map<String, String> _state = {};
+
+  TraceState.empty();
+
+  TraceState.fromString(String traceState) {
+    final stateElements = traceState.split(',');
+
+    // Incoming state doesn't contain valid matchings of comma-separated
+    // "key=value,key=value" pairs. Note: an invalid value with both a = and
+    // a comma will still be converted, incorrectly.
+    if (!stateElements.every((element) => element.contains('='))) {
+      return;
+    }
+
+    for (final element in stateElements) {
+      final entry = element.split('=');
+      if (entry.length == 2) {
+        put(entry.first, entry.last);
+      }
+    }
+  }
+
+  static TraceState getDefault() => TraceState.empty();
+
+  /// Determine if the given key is valid.
+  ///
+  /// Key is an opaque string up to 256 characters printable. It MUST begin
+  /// with a lowercase letter, and can only contain lowercase letters a-z,
+  /// digits 0-9, underscores _, dashes -, asterisks *, and forward slashes /.
+  /// For multi-tenant vendor scenarios, an at sign (@) can be used to prefix
+  /// the vendor name. The tenant id (before the '@') is limited to 240
+  /// characters and the vendor id is limited to 13 characters. If in the
+  /// multi-tenant vendor format, then the first character may additionally
+  /// be numeric.
+  static bool _isValidKey(String key) {
+    if (key == null || key.length > _KEY_MAX_SIZE || key.isEmpty) {
+      return false;
+    }
+
+    final match = validKeyRegex.matchAsPrefix(key);
+
+    return (match != null) && (match.group(0) == key);
+  }
+
+  /// Determine if the given value is valid.
+  ///
+  /// Value an is opaque string up to 256 characters printable ASCII RFC0020
+  /// characters (i.e., the range 0x20 to 0x7E) except comma , and =.
+  static bool _isValidValue(String value) {
+    if (value == null || value.length > _VALUE_MAX_SIZE || value.isEmpty) {
+      return false;
+    }
+
+    final match = validValueRegex.matchAsPrefix(value);
+
+    return (match != null) && (match.group(0) == value);
+  }
+
+  @override
+  String get(String key) => _state[key];
+
+  /// Adds a key value pairs to the TraceState.
+  ///
+  /// Key is an opaque string up to 256 characters printable. It MUST begin
+  /// with a lowercase letter, and can only contain lowercase letters a-z,
+  /// digits 0-9, underscores _, dashes -, asterisks *, and forward slashes /.
+  /// For multi-tenant vendor scenarios, an at sign (@) can be used to prefix
+  /// the vendor name. The tenant id (before the '@') is limited to 240
+  /// characters and the vendor id is limited to 13 characters. If in the
+  /// multi-tenant vendor format, then the first character may additionally
+  /// be numeric.
+  ///
+  /// Value is opaque string up to 256 characters printable ASCII RFC0020
+  /// characters (i.e., the range 0x20 to 0x7E) except comma , and =.
+  @override
+  void put(String key, String value) {
+    if (_isValidKey(key) &&
+        _isValidValue(value) &&
+        size < _MAX_KEY_VALUE_PAIRS) {
+      _state[key] = value;
+    }
+  }
+
+  @override
+  String toString() {
+    if (isEmpty) {
+      return '';
+    }
+
+    final state_entries = _state.entries;
+    var state = '${state_entries.first.key}=${state_entries.first.value}';
+
+    state_entries.skip(1).forEach((entry) {
+      state += ',${entry.key}=${entry.value}';
+    });
+
+    return state;
+  }
+
+  @override
+  bool get isEmpty => _state.isEmpty;
+
+  @override
+  int get size => _state.length;
+}

--- a/lib/src/sdk/trace/tracer_provider.dart
+++ b/lib/src/sdk/trace/tracer_provider.dart
@@ -1,12 +1,12 @@
+import '../../api/instrumentation_library.dart'
+    as version_api;
 import '../../api/trace/tracer_provider.dart' as api;
+import '../instrumentation_library.dart';
 import 'exporters/console_exporter.dart';
+import 'id_generator.dart';
 import 'span_processors/simple_processor.dart';
 import 'span_processors/span_processor.dart';
 import 'tracer.dart';
-import 'package:opentelemetry/src/sdk/trace/id_generator.dart';
-import 'package:opentelemetry/src/api/instrumentation_library.dart'
-    as version_api;
-import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
 
 /// A registry for creating named [Tracer]s.
 class TracerProvider implements api.TracerProvider {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,16 @@ environment:
 
 dependencies:
   fixnum: ^0.10.0
+  frugal:
+    hosted:
+      name: frugal
+      url: https://pub.workiva.org
   http: ^0.12.0
-  logging: ^0.11.0
+  logging: ^0.11.4
   protobuf: ^1.1.0
 
 dev_dependencies:
-  mockito: ^5.0.7
+  meta: 1.6.0 # https://github.com/angulardart/angular/issues/1967
+  mockito: ^4.1.4  # TODO: Fix this.  Version 5.0.7 inompatible with Frugal.
   test: ^1.16.5
   workiva_analysis_options: ^1.2.2

--- a/test/integration/sdk/propagation/w3c_trace_context_propagator_test.dart
+++ b/test/integration/sdk/propagation/w3c_trace_context_propagator_test.dart
@@ -1,0 +1,125 @@
+import 'package:frugal/frugal.dart';
+import 'package:opentelemetry/api.dart' as api;
+import 'package:opentelemetry/src/api/context/context.dart';
+import 'package:opentelemetry/src/api/trace/context_utils.dart';
+import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
+import 'package:opentelemetry/src/sdk/trace/id_generator.dart';
+import 'package:opentelemetry/src/sdk/trace/propagation/extractors/fcontext_extractor.dart';
+import 'package:opentelemetry/src/sdk/trace/propagation/injectors/fcontext_injector.dart';
+import 'package:opentelemetry/src/sdk/trace/propagation/w3c_trace_context_propagator.dart';
+import 'package:opentelemetry/src/sdk/trace/span.dart';
+import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
+import 'package:opentelemetry/src/sdk/trace/tracer.dart';
+import 'package:opentelemetry/src/sdk/trace/tracer_provider.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('inject and extract trace context', () {
+    final testIdGenerator = IdGenerator();
+    final testSpan = Span(
+        'TestSpan',
+        SpanContext(
+            TraceId.fromString('4bf92f3577b34da6a3ce929d0e0e4736'),
+            SpanId.fromString('0000000000c0ffee'),
+            TraceFlags(api.TraceFlags.SAMPLED_FLAG),
+            TraceState.fromString('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE')),
+        SpanId.fromString('00f067aa0ba902b7'),
+        [],
+        Tracer('TestTracer', [], testIdGenerator, InstrumentationLibrary()));
+    final testPropagator = W3CTraceContextPropagator();
+    final testCarrier = FContext();
+    final testContext = api.setSpan(Context.current, testSpan);
+
+    testPropagator.inject(testContext, testCarrier, FContextInjector());
+    final Span resultSpan = getSpan(
+        testPropagator.extract(testContext, testCarrier, FContextExtractor()));
+
+    expect(resultSpan.parentSpanId, isNull);
+    expect(resultSpan.spanContext.isValid, isTrue);
+    expect(
+        resultSpan.spanContext.spanId.toString(), equals('0000000000c0ffee'));
+    expect(resultSpan.spanContext.traceId.toString(),
+        equals('4bf92f3577b34da6a3ce929d0e0e4736'));
+    expect(resultSpan.spanContext.traceFlags.isValid, isTrue);
+    expect(resultSpan.spanContext.traceFlags.sampled, isTrue);
+    expect(resultSpan.spanContext.traceState.toString(),
+        equals('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'));
+  });
+
+  test('inject and extract invalid trace parent', () {
+    final testIdGenerator = IdGenerator();
+    final testSpan = Span(
+        'TestSpan',
+        SpanContext(
+            TraceId.fromString('00000000000000000000000000000000'),
+            SpanId.fromString('0000000000c0ffee'),
+            TraceFlags(api.TraceFlags.INVALID),
+            TraceState.fromString('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE')),
+        SpanId.fromString('0000000000000000'),
+        [],
+        Tracer('TestTracer', [], testIdGenerator, InstrumentationLibrary()));
+    final testPropagator = W3CTraceContextPropagator();
+    final testCarrier = FContext();
+    final testContext = api.setSpan(Context.current, testSpan);
+
+    testPropagator.inject(testContext, testCarrier, FContextInjector());
+    final Span resultSpan = getSpan(
+        testPropagator.extract(testContext, testCarrier, FContextExtractor()));
+
+    expect(resultSpan.parentSpanId, isNull);
+    expect(resultSpan.spanContext.isValid, isFalse);
+    expect(
+        resultSpan.spanContext.spanId.toString(), equals('0000000000c0ffee'));
+    expect(resultSpan.spanContext.traceId.toString(),
+        equals('00000000000000000000000000000000'));
+    expect(resultSpan.spanContext.traceFlags.isValid, isFalse);
+    expect(resultSpan.spanContext.traceFlags.sampled, isFalse);
+    expect(resultSpan.spanContext.traceState.toString(),
+        equals('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'));
+  });
+
+  test('extract and inject with child span', () {
+    final testIdGenerator = IdGenerator();
+    final testSpan = Span(
+        'TestSpan',
+        SpanContext(
+            TraceId.fromString('4bf92f3577b34da6a3ce929d0e0e4736'),
+            SpanId.fromString('0000000000c0ffee'),
+            TraceFlags(api.TraceFlags.SAMPLED_FLAG),
+            TraceState.fromString('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE')),
+        SpanId.fromString('00f067aa0ba902b7'),
+        [],
+        Tracer('TestTracer', [], testIdGenerator, InstrumentationLibrary()));
+    final tracer =
+        TracerProvider(processors: []).getTracer('appName', version: '1.0.0');
+    final testPropagator = W3CTraceContextPropagator();
+    final testCarrier = FContext();
+
+    // Inject and extract a test Span from a Context, as when an outbound
+    // call is made and received by another service.
+    final testContext = api.setSpan(Context.current, testSpan);
+    testPropagator.inject(testContext, testCarrier, FContextInjector());
+    final Span parentSpan = getSpan(
+        testPropagator.extract(testContext, testCarrier, FContextExtractor()));
+
+    // Use the transmitted Span as a receiver.
+    Span resultSpan;
+    withContext(setSpan(Context.current, parentSpan), () {
+      resultSpan = tracer.startSpan('doWork')..end();
+    });
+
+    // Verify that the original Span is set as the parent.
+    expect(resultSpan.parentSpanId.toString(),
+        equals(testSpan.spanContext.spanId.toString()));
+    expect(resultSpan.spanContext.traceId.toString(),
+        equals(testSpan.spanContext.traceId.toString()));
+    expect(resultSpan.spanContext.traceState.toString(),
+        equals(testSpan.spanContext.traceState.toString()));
+    expect(resultSpan.spanContext.traceFlags.toString(),
+        equals(testSpan.spanContext.traceFlags.toString()));
+  });
+}

--- a/test/integration/sdk/span_context_test.dart
+++ b/test/integration/sdk/span_context_test.dart
@@ -1,0 +1,68 @@
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
+import 'package:test/test.dart';
+import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/api.dart' as api;
+
+void main() {
+  test('valid context evaluates as valid', () {
+    final spanId = SpanId([1, 2, 3]);
+    final traceId = TraceId([4, 5, 6]);
+    final traceFlags = TraceFlags(api.TraceFlags.SAMPLED_FLAG);
+    final traceState = TraceState.empty();
+
+    final testSpanContext =
+        SpanContext(traceId, spanId, traceFlags, traceState);
+
+    expect(testSpanContext.isValid, isTrue);
+    expect(testSpanContext.traceId, same(traceId));
+    expect(testSpanContext.spanId, same(spanId));
+    expect(testSpanContext.traceFlags, same(traceFlags));
+    expect(testSpanContext.traceState, same(traceState));
+  });
+
+  test('invalid parsed parent span ID from header creates an invalid context',
+      () {
+    final spanId = SpanId.fromString('0000000000000000');
+    final traceId = TraceId([4, 5, 6]);
+    final traceFlags = TraceFlags(api.TraceFlags.SAMPLED_FLAG);
+    final traceState = TraceState.empty();
+
+    final testSpanContext =
+        SpanContext(traceId, spanId, traceFlags, traceState);
+
+    expect(testSpanContext.isValid, isFalse);
+    expect(testSpanContext.traceId, same(traceId));
+    expect(testSpanContext.spanId, same(spanId));
+    expect(testSpanContext.traceFlags, same(traceFlags));
+    expect(testSpanContext.traceState, same(traceState));
+  });
+
+  test('invalid parsed trace ID from header creates an invalid context', () {
+    final spanId = SpanId([1, 2, 3]);
+    final traceId = TraceId.fromString('00000000000000000000000000000000');
+    final traceFlags = TraceFlags(api.TraceFlags.SAMPLED_FLAG);
+    final traceState = TraceState.empty();
+
+    final testSpanContext =
+        SpanContext(traceId, spanId, traceFlags, traceState);
+
+    expect(testSpanContext.isValid, isFalse);
+    expect(testSpanContext.traceId, same(traceId));
+    expect(testSpanContext.spanId, same(spanId));
+    expect(testSpanContext.traceFlags, same(traceFlags));
+    expect(testSpanContext.traceState, same(traceState));
+  });
+
+  test('valid context evaluates as valid', () {
+    final testSpanContext = SpanContext.invalid();
+
+    expect(testSpanContext.isValid, isFalse);
+    expect(testSpanContext.traceId.isValid, isFalse);
+    expect(testSpanContext.isValid, isFalse);
+    expect(testSpanContext.traceFlags.isValid, isFalse);
+    expect(testSpanContext.traceState.isEmpty, isTrue);
+  });
+}

--- a/test/integration/sdk/span_test.dart
+++ b/test/integration/sdk/span_test.dart
@@ -5,6 +5,10 @@ import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
 import 'package:opentelemetry/src/sdk/trace/id_generator.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/api/trace/trace_flags.dart' as api;
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
 import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
 import 'package:opentelemetry/src/sdk/trace/tracer.dart';
 import 'package:test/test.dart';
@@ -15,16 +19,18 @@ void main() {
   test('span set and end time', () {
     final mockProcessor1 = MockSpanProcessor();
     final mockProcessor2 = MockSpanProcessor();
+    final parentSpanId = SpanId([4, 5, 6]);
     final span = Span(
         'foo',
-        SpanContext([1, 2, 3], [7, 8, 9], TraceState()),
-        [4, 5, 6],
+        SpanContext(TraceId([1, 2, 3]), SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.NONE), TraceState.empty()),
+        parentSpanId,
         [mockProcessor1, mockProcessor2],
         Tracer('bar', [], IdGenerator(), InstrumentationLibrary()));
 
     expect(span.startTime, isNotNull);
     expect(span.endTime, isNull);
-    expect(span.parentSpanId, [4, 5, 6]);
+    expect(span.parentSpanId, same(parentSpanId));
     expect(span.name, 'foo');
 
     verify(mockProcessor1.onStart()).called(1);
@@ -44,8 +50,9 @@ void main() {
   test('span status', () {
     final span = Span(
         'foo',
-        SpanContext([1, 2, 3], [7, 8, 9], TraceState()),
-        [4, 5, 6],
+        SpanContext(TraceId([1, 2, 3]), SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.NONE), TraceState.empty()),
+        SpanId([4, 5, 6]),
         [],
         Tracer('bar', [], IdGenerator(), InstrumentationLibrary()));
 
@@ -105,8 +112,9 @@ void main() {
     };
     final span = Span(
         'foo',
-        SpanContext([1, 2, 3], [7, 8, 9], TraceState()),
-        [4, 5, 6],
+        SpanContext(TraceId([1, 2, 3]), SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.NONE), TraceState.empty()),
+        SpanId([4, 5, 6]),
         [],
         Tracer('bar', [], IdGenerator(), InstrumentationLibrary()));
 

--- a/test/unit/api/context_utils_test.dart
+++ b/test/unit/api/context_utils_test.dart
@@ -1,10 +1,13 @@
 import 'package:mockito/mockito.dart';
-import 'package:opentelemetry/src/api/context/context.dart';
+import 'package:opentelemetry/api.dart' as api;
 import 'package:opentelemetry/src/api/trace/context_utils.dart';
 import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
 import 'package:opentelemetry/src/sdk/trace/id_generator.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
 import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
 import 'package:opentelemetry/src/sdk/trace/tracer.dart';
 import 'package:test/test.dart';
@@ -12,27 +15,28 @@ import 'package:test/test.dart';
 import '../mocks.dart';
 
 void main() {
-  final testSpanContext = SpanContext([1, 2, 3], [7, 8, 9], TraceState());
-  final testSpan = Span('foo', testSpanContext, [4, 5, 6], [],
+  final testSpanContext = SpanContext(TraceId([1, 2, 3]), SpanId([7, 8, 9]),
+      TraceFlags(api.TraceFlags.NONE), TraceState.empty());
+  final testSpan = Span('foo', testSpanContext, SpanId([4, 5, 6]), [],
       Tracer('bar', [], IdGenerator(), InstrumentationLibrary()));
 
   group('getSpan', () {
     test('returns Span when exists', () {
-      final parentContext = Context.current;
+      final parentContext = api.Context.current;
       final childContext = parentContext.setValue(spanKey, testSpan);
 
-      expect(getSpan(childContext), same(testSpan));
+      expect(api.getSpan(childContext), same(testSpan));
     });
 
     test('returns null when not exists', () {
-      final context = Context.current;
+      final context = api.Context.current;
 
-      expect(getSpan(context), isNull);
+      expect(api.getSpan(context), isNull);
     });
   });
 
   group('context_utils', () {
-    Context mockContext;
+    api.Context mockContext;
 
     setUpAll(() {
       mockContext = MockContext();
@@ -45,7 +49,7 @@ void main() {
     test('getSpanContext returns Span when exists', () {
       when(mockContext.getValue(spanKey)).thenReturn(testSpan);
 
-      expect(getSpanContext(mockContext), same(testSpanContext));
+      expect(api.getSpanContext(mockContext), same(testSpanContext));
 
       verify(mockContext.getValue(spanKey)).called(1);
     });
@@ -53,13 +57,13 @@ void main() {
     test('getSpanContext returns Span when not exists', () {
       when(mockContext.getValue(spanKey)).thenReturn(null);
 
-      expect(getSpanContext(mockContext), isNull);
+      expect(api.getSpanContext(mockContext), isNull);
 
       verify(mockContext.getValue(spanKey)).called(1);
     });
 
     test('setSpan sets', () {
-      setSpan(mockContext, testSpan);
+      api.setSpan(mockContext, testSpan);
 
       verify(mockContext.setValue(spanKey, testSpan)).called(1);
     });

--- a/test/unit/sdk/exporters/collector_exporter_test.dart
+++ b/test/unit/sdk/exporters/collector_exporter_test.dart
@@ -10,6 +10,10 @@ import 'package:opentelemetry/src/sdk/instrumentation_library.dart'
     as instrumentation_sdk;
 import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/api/trace/trace_flags.dart' as api;
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
 import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
 import 'package:opentelemetry/src/sdk/trace/tracer.dart';
 import 'package:test/test.dart';
@@ -32,13 +36,19 @@ void main() {
   test('sends spans', () {
     final tracer = Tracer(
         'bar', [], IdGenerator(), instrumentation_sdk.InstrumentationLibrary());
-    final span1 = Span('foo', SpanContext([1, 2, 3], [7, 8, 9], TraceState()),
-        [4, 5, 6], [], tracer)
+    final span1 = Span(
+        'foo',
+        SpanContext(TraceId([1, 2, 3]), SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.NONE), TraceState.empty()),
+        SpanId([4, 5, 6]),
+        [],
+        tracer)
       ..end();
     final span2 = Span(
         'baz',
-        SpanContext([1, 2, 3], [10, 11, 12], TraceState()),
-        [4, 5, 6],
+        SpanContext(TraceId([1, 2, 3]), SpanId([10, 11, 12]),
+            TraceFlags(api.TraceFlags.NONE), TraceState.empty()),
+        SpanId([4, 5, 6]),
         [],
         tracer)
       ..end();
@@ -84,8 +94,13 @@ void main() {
   test('does not send spans when shutdown', () {
     final tracer = Tracer(
         'bar', [], IdGenerator(), instrumentation_sdk.InstrumentationLibrary());
-    final span = Span('foo', SpanContext([1, 2, 3], [7, 8, 9], TraceState()),
-        [4, 5, 6], [], tracer)
+    final span = Span(
+        'foo',
+        SpanContext(TraceId([1, 2, 3]), SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.NONE), TraceState.empty()),
+        SpanId([4, 5, 6]),
+        [],
+        tracer)
       ..end();
 
     CollectorExporter(uri, httpClient: mockClient)

--- a/test/unit/sdk/exporters/console_exporter_test.dart
+++ b/test/unit/sdk/exporters/console_exporter_test.dart
@@ -5,6 +5,10 @@ import 'package:opentelemetry/src/sdk/trace/exporters/console_exporter.dart';
 import 'package:opentelemetry/src/sdk/trace/id_generator.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/api/trace/trace_flags.dart' as api;
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
 import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
 import 'package:opentelemetry/src/sdk/trace/tracer.dart';
 import 'package:test/test.dart';
@@ -27,8 +31,9 @@ void main() {
   test('prints', overridePrint(() {
     final span = Span(
         'foo',
-        SpanContext([1, 2, 3], [7, 8, 9], TraceState()),
-        [4, 5, 6],
+        SpanContext(TraceId([1, 2, 3]), SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.NONE), TraceState.empty()),
+        SpanId([4, 5, 6]),
         [],
         Tracer('bar', [], IdGenerator(), InstrumentationLibrary()))
       ..end();
@@ -44,8 +49,9 @@ void main() {
   test('does not print after shutdown', overridePrint(() {
     final span = Span(
         'foo',
-        SpanContext([1, 2, 3], [7, 8, 9], TraceState()),
-        [4, 5, 6],
+        SpanContext(TraceId([1, 2, 3]), SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.NONE), TraceState.empty()),
+        SpanId([4, 5, 6]),
         [],
         Tracer('bar', [], IdGenerator(), InstrumentationLibrary()));
 

--- a/test/unit/sdk/propagation/w3c_trace_context_propagator_test.dart
+++ b/test/unit/sdk/propagation/w3c_trace_context_propagator_test.dart
@@ -1,0 +1,218 @@
+import 'package:frugal/frugal.dart';
+import 'package:opentelemetry/api.dart' as api;
+import 'package:opentelemetry/src/api/context/context.dart';
+import 'package:opentelemetry/src/api/trace/context_utils.dart';
+import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
+import 'package:opentelemetry/src/sdk/trace/id_generator.dart';
+import 'package:opentelemetry/src/sdk/trace/propagation/extractors/fcontext_extractor.dart';
+import 'package:opentelemetry/src/sdk/trace/propagation/injectors/fcontext_injector.dart';
+import 'package:opentelemetry/src/sdk/trace/propagation/w3c_trace_context_propagator.dart';
+import 'package:opentelemetry/src/sdk/trace/span.dart';
+import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
+import 'package:opentelemetry/src/sdk/trace/tracer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('extract trace context', () {
+    final testPropagator = W3CTraceContextPropagator();
+    final testCarrier = FContext();
+
+    FContextInjector()
+      ..set(testCarrier, 'traceparent',
+          '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
+      ..set(
+          testCarrier, 'tracestate', 'rojo=00f067aa0ba902b7,congo=t61rcWkgMzE');
+    final resultContext = testPropagator.extract(
+        Context.current, testCarrier, FContextExtractor());
+    final Span resultSpan = getSpan(resultContext);
+
+    expect(resultSpan.parentSpanId, isNull);
+    expect(resultSpan.spanContext.isValid, isTrue);
+    expect(
+        resultSpan.spanContext.spanId.toString(), equals('00f067aa0ba902b7'));
+    expect(resultSpan.spanContext.traceId.toString(),
+        equals('4bf92f3577b34da6a3ce929d0e0e4736'));
+    expect(resultSpan.spanContext.traceFlags.isValid, isTrue);
+    expect(resultSpan.spanContext.traceFlags.sampled, isTrue);
+    expect(resultSpan.spanContext.traceState.toString(),
+        equals('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'));
+  });
+
+  test('extract invalid trace parent', () {
+    final testPropagator = W3CTraceContextPropagator();
+    final testCarrier = FContext();
+
+    FContextInjector()
+      ..set(testCarrier, 'traceparent',
+          '00-00000000000000000000000000000000-0000000000000000-ff')
+      ..set(
+          testCarrier, 'tracestate', 'rojo=00f067aa0ba902b7,congo=t61rcWkgMzE');
+    final resultContext = testPropagator.extract(
+        Context.current, testCarrier, FContextExtractor());
+    final Span resultSpan = getSpan(resultContext);
+
+    expect(resultSpan.parentSpanId, isNull);
+    expect(resultSpan.spanContext.isValid, isFalse);
+    expect(
+        resultSpan.spanContext.spanId.toString(), equals('0000000000000000'));
+    expect(resultSpan.spanContext.traceId.toString(),
+        equals('00000000000000000000000000000000'));
+    expect(resultSpan.spanContext.traceFlags.isValid, isFalse);
+    expect(resultSpan.spanContext.traceFlags.sampled, isFalse);
+    expect(resultSpan.spanContext.traceState.toString(),
+        equals('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'));
+  });
+
+  test('extract missing trace parent', () {
+    final testPropagator = W3CTraceContextPropagator();
+    final testCarrier = FContext();
+
+    final resultContext = testPropagator.extract(
+        Context.current, testCarrier, FContextExtractor());
+    final Span resultSpan = getSpan(resultContext);
+
+    expect(resultSpan, isNull);
+  });
+
+  test('extract malformed trace parent', () {
+    final testPropagator = W3CTraceContextPropagator();
+    final testCarrier = FContext();
+
+    FContextInjector()
+      ..set(testCarrier, 'traceparent',
+          '00-4bf92^3577b34da6q3ce929d0e0e4736-00f@67aa0bak02b7-01')
+      ..set(
+          testCarrier, 'tracestate', 'rojo=00f067aa0ba902b7,congo=t61rcWkgMzE');
+    final resultContext = testPropagator.extract(
+        Context.current, testCarrier, FContextExtractor());
+    final Span resultSpan = getSpan(resultContext);
+
+    // Extract should not allow a Span with malformed IDs to be attached to
+    // a Context.  Thus, there should be no Span on this context.
+    expect(resultSpan, isNull);
+  });
+
+  test('extract malformed trace state', () {
+    final testPropagator = W3CTraceContextPropagator();
+    final testCarrier = FContext();
+
+    FContextInjector()
+      ..set(testCarrier, 'traceparent',
+          '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
+      ..set(testCarrier, 'tracestate',
+          'rojo=00f067aa,0ba902b7,con@go=t61rcWk=gMzE');
+    final Span resultSpan = getSpan(testPropagator.extract(
+        Context.current, testCarrier, FContextExtractor()));
+
+    expect(resultSpan.parentSpanId, isNull);
+    expect(resultSpan.spanContext.isValid, isTrue);
+    expect(
+        resultSpan.spanContext.spanId.toString(), equals('00f067aa0ba902b7'));
+    expect(resultSpan.spanContext.traceId.toString(),
+        equals('4bf92f3577b34da6a3ce929d0e0e4736'));
+    expect(resultSpan.spanContext.traceFlags.isValid, isTrue);
+    expect(resultSpan.spanContext.traceFlags.sampled, isTrue);
+    // Extract should not allow a TraceState with malformed IDs to be attached to
+    // a Context.  Thus, there should be an empty TraceState on this context.
+    expect(resultSpan.spanContext.traceState.toString(), equals(''));
+  });
+
+  test('inject trace parent', () {
+    final testIdGenerator = IdGenerator();
+    final testSpan = Span(
+        'TestSpan',
+        SpanContext(
+            TraceId.fromString('4bf92f3577b34da6a3ce929d0e0e4736'),
+            SpanId.fromString('0000000000c0ffee'),
+            TraceFlags(api.TraceFlags.SAMPLED_FLAG),
+            TraceState.fromString('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE')),
+        SpanId.fromString('00f067aa0ba902b7'),
+        [],
+        Tracer('TestTracer', [], testIdGenerator, InstrumentationLibrary()));
+    final testCarrier = FContext();
+    final testContext = api.setSpan(Context.current, testSpan);
+
+    W3CTraceContextPropagator()
+        .inject(testContext, testCarrier, FContextInjector());
+
+    expect(testCarrier.requestHeader('traceparent'),
+        equals('00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000c0ffee-01'));
+    expect(testCarrier.requestHeader('tracestate'),
+        equals('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'));
+  });
+
+  test('inject invalid trace parent', () {
+    final testIdGenerator = IdGenerator();
+    final testSpan = Span(
+        'TestSpan',
+        SpanContext(
+            TraceId.fromString('00000000000000000000000000000000'),
+            SpanId.fromString('0000000000000000'),
+            TraceFlags(api.TraceFlags.INVALID),
+            TraceState.fromString('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE')),
+        SpanId.fromString('0000000000c0ffee'),
+        [],
+        Tracer('TestTracer', [], testIdGenerator, InstrumentationLibrary()));
+    final testCarrier = FContext();
+    final testContext = api.setSpan(Context.current, testSpan);
+
+    W3CTraceContextPropagator()
+        .inject(testContext, testCarrier, FContextInjector());
+
+    expect(testCarrier.requestHeader('traceparent'),
+        equals('00-00000000000000000000000000000000-0000000000000000-ff'));
+    expect(testCarrier.requestHeader('tracestate'),
+        equals('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'));
+  });
+
+  test('header regex, valid input', () {
+    const traceParentHeader =
+        '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+    final parentHeaderMatch = W3CTraceContextPropagator.traceParentHeaderRegEx
+        .firstMatch(traceParentHeader);
+    final parentHeaderFields = Map<String, String>.fromIterable(
+        parentHeaderMatch.groupNames,
+        key: (element) => element.toString(),
+        value: (element) => parentHeaderMatch.namedGroup(element));
+
+    expect(
+        parentHeaderFields,
+        equals({
+          'version': '00',
+          'traceid': '4bf92f3577b34da6a3ce929d0e0e4736',
+          'parentid': '00f067aa0ba902b7',
+          'traceflags': '01'
+        }));
+  });
+  test('header regex, invalid trace and parent IDs', () {
+    const traceParentHeader =
+        '00-00000000000000000000000000000000-0000000000000000-00';
+    final parentHeaderMatch = W3CTraceContextPropagator.traceParentHeaderRegEx
+        .firstMatch(traceParentHeader);
+    final parentHeaderFields = Map<String, String>.fromIterable(
+        parentHeaderMatch.groupNames,
+        key: (element) => element.toString(),
+        value: (element) => parentHeaderMatch.namedGroup(element));
+
+    expect(
+        parentHeaderFields,
+        equals({
+          'version': '00',
+          'traceid': '00000000000000000000000000000000',
+          'parentid': '0000000000000000',
+          'traceflags': '00'
+        }));
+  });
+  test('header regex, malformed trace and parent IDs', () {
+    const traceParentHeader =
+        '00-4bf92^3577b34da6q3ce929d0e0e4736-00f@67aa0bak02b7-01';
+    final parentHeaderMatch = W3CTraceContextPropagator.traceParentHeaderRegEx
+        .firstMatch(traceParentHeader);
+
+    expect(parentHeaderMatch, isNull);
+  });
+}

--- a/test/unit/sdk/span_context_test.dart
+++ b/test/unit/sdk/span_context_test.dart
@@ -1,14 +1,23 @@
 import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/api/trace/trace_flags.dart' as api;
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
 import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
 import 'package:test/test.dart';
 
 void main() {
   test('spanContext getters', () {
-    final traceState = TraceState();
-    final spanContext = SpanContext([1, 2, 3], [4, 5, 6], traceState);
+    final spanId = SpanId([4, 5, 6]);
+    final traceId = TraceId([1, 2, 3]);
+    final traceFlags = TraceFlags(api.TraceFlags.NONE);
+    final traceState = TraceState.empty();
 
-    expect(spanContext.traceId, [1, 2, 3]);
-    expect(spanContext.spanId, [4, 5, 6]);
+    final spanContext = SpanContext(traceId, spanId, traceFlags, traceState);
+
+    expect(spanContext.traceId, same(traceId));
+    expect(spanContext.spanId, same(spanId));
+    expect(spanContext.traceFlags, same(traceFlags));
     expect(spanContext.traceState, same(traceState));
   });
 }

--- a/test/unit/sdk/span_id_test.dart
+++ b/test/unit/sdk/span_id_test.dart
@@ -1,0 +1,57 @@
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/api.dart' as api;
+import 'package:test/test.dart';
+
+class MockIdGenerator implements api.IdGenerator {
+  @override
+  List<int> generateSpanId() {
+    return [1, 2, 3, 4, 5, 6, 7, 8];
+  }
+
+  @override
+  List<int> generateTraceId() {
+    throw UnimplementedError();
+  }
+}
+
+void main() {
+  test('create with int list', () {
+    final testSpanId = SpanId([1, 2, 3]);
+
+    expect(testSpanId.get(), equals([1, 2, 3]));
+    expect(testSpanId.isValid, isTrue);
+    expect(testSpanId.toString(), equals('010203'));
+  });
+
+  test('create from id generator', () {
+    final testSpanId = SpanId.fromIdGenerator(MockIdGenerator());
+
+    expect(testSpanId.get(), equals([1, 2, 3, 4, 5, 6, 7, 8]));
+    expect(testSpanId.isValid, isTrue);
+    expect(testSpanId.toString(), equals('0102030405060708'));
+  });
+
+  test('create from string', () {
+    final testSpanId = SpanId.fromString('010203');
+
+    expect(testSpanId.get(), equals([0, 0, 0, 0, 0, 1, 2, 3]));
+    expect(testSpanId.isValid, isTrue);
+    expect(testSpanId.toString(), equals('0000000000010203'));
+  });
+
+  test('create invalid id', () {
+    final testSpanId = SpanId.invalid();
+
+    expect(testSpanId.get(), equals([0, 0, 0, 0, 0, 0, 0, 0]));
+    expect(testSpanId.isValid, isFalse);
+    expect(testSpanId.toString(), equals('0000000000000000'));
+  });
+
+  test('create root id', () {
+    final testSpanId = SpanId.root();
+
+    expect(testSpanId.get(), equals([]));
+    expect(testSpanId.isValid, true);
+    expect(testSpanId.toString(), equals(''));
+  });
+}

--- a/test/unit/sdk/span_test.dart
+++ b/test/unit/sdk/span_test.dart
@@ -1,7 +1,11 @@
+import 'package:opentelemetry/src/api/trace/trace_flags.dart' as api;
 import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
 import 'package:opentelemetry/src/sdk/trace/id_generator.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
 import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
 import 'package:opentelemetry/src/sdk/trace/tracer.dart';
 import 'package:test/test.dart';
@@ -10,8 +14,9 @@ void main() {
   test('span change name', () {
     final span = Span(
         'foo',
-        SpanContext([1, 2, 3], [7, 8, 9], TraceState()),
-        [4, 5, 6],
+        SpanContext(TraceId([1, 2, 3]), SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.NONE), TraceState.empty()),
+        SpanId([4, 5, 6]),
         [],
         Tracer('bar', [], IdGenerator(), InstrumentationLibrary()));
     expect(span.name, 'foo');

--- a/test/unit/sdk/trace_flags_test.dart
+++ b/test/unit/sdk/trace_flags_test.dart
@@ -1,0 +1,48 @@
+import 'package:test/test.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/api/trace/trace_flags.dart' as api;
+
+void main() {
+  test('create empty', () {
+    final testTraceFlags = TraceFlags(api.TraceFlags.NONE);
+
+    expect(testTraceFlags.sampled, isFalse);
+    expect(testTraceFlags.isValid, isTrue);
+  });
+
+  test('create sampled', () {
+    final testTraceFlags = TraceFlags(api.TraceFlags.SAMPLED_FLAG);
+
+    expect(testTraceFlags.sampled, isTrue);
+    expect(testTraceFlags.isValid, isTrue);
+  });
+
+  test('create from string', () {
+    final testTraceFlags = TraceFlags.fromString('01');
+
+    expect(testTraceFlags.sampled, isTrue);
+    expect(testTraceFlags.isValid, isTrue);
+  });
+
+  test('create invalid', () {
+    final testTraceFlags = TraceFlags.invalid();
+
+    expect(testTraceFlags.sampled, isFalse);
+    expect(testTraceFlags.isValid, isFalse);
+  });
+
+  test('set sampled', () {
+    final testTraceFlags = TraceFlags(api.TraceFlags.NONE)..sampled = true;
+
+    expect(testTraceFlags.sampled, isTrue);
+    expect(testTraceFlags.isValid, isTrue);
+  });
+
+  test('unset sampled', () {
+    final testTraceFlags = TraceFlags(api.TraceFlags.SAMPLED_FLAG)
+      ..sampled = false;
+
+    expect(testTraceFlags.sampled, isFalse);
+    expect(testTraceFlags.isValid, isTrue);
+  });
+}

--- a/test/unit/sdk/trace_id_test.dart
+++ b/test/unit/sdk/trace_id_test.dart
@@ -1,0 +1,52 @@
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
+import 'package:opentelemetry/api.dart' as api;
+import 'package:test/test.dart';
+
+class MockIdGenerator implements api.IdGenerator {
+  @override
+  List<int> generateTraceId() {
+    return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+  }
+
+  @override
+  List<int> generateSpanId() {
+    throw UnimplementedError();
+  }
+}
+
+void main() {
+  test('create with int list', () {
+    final testTraceId = TraceId([1, 2, 3]);
+
+    expect(testTraceId.get(), equals([1, 2, 3]));
+    expect(testTraceId.isValid, isTrue);
+    expect(testTraceId.toString(), equals('010203'));
+  });
+
+  test('create from id generator', () {
+    final testTraceId = TraceId.fromIdGenerator(MockIdGenerator());
+
+    expect(testTraceId.get(),
+        equals([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]));
+    expect(testTraceId.isValid, isTrue);
+    expect(testTraceId.toString(), equals('0102030405060708090a0b0c0d0e0f'));
+  });
+
+  test('create from string', () {
+    final testTraceId = TraceId.fromString('010203');
+
+    expect(testTraceId.get(),
+        equals([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3]));
+    expect(testTraceId.isValid, isTrue);
+    expect(testTraceId.toString(), equals('00000000000000000000000000010203'));
+  });
+
+  test('create invalid id', () {
+    final testTraceId = TraceId.invalid();
+
+    expect(testTraceId.get(),
+        equals([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
+    expect(testTraceId.isValid, isFalse);
+    expect(testTraceId.toString(), equals('00000000000000000000000000000000'));
+  });
+}

--- a/test/unit/sdk/trace_state_test.dart
+++ b/test/unit/sdk/trace_state_test.dart
@@ -1,0 +1,113 @@
+import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('create empty', () {
+    final testTraceState = TraceState.empty();
+
+    expect(testTraceState.toString(), equals(''));
+    expect(testTraceState.isEmpty, isTrue);
+    expect(testTraceState.size, equals(0));
+  });
+
+  test('create from string', () {
+    final testTraceState = TraceState.fromString('key1=value2,key@2=value1');
+
+    expect(testTraceState.get('key1'), equals('value2')); // Regular key.
+    expect(testTraceState.get('key@2'), equals('value1')); // Vendor key.
+    expect(testTraceState.toString(), equals('key1=value2,key@2=value1'));
+    expect(testTraceState.isEmpty, isFalse);
+    expect(testTraceState.size, equals(2));
+  });
+
+  test('get default', () {
+    final testTraceState = TraceState.getDefault();
+
+    expect(testTraceState.toString(), equals(''));
+    expect(testTraceState.isEmpty, isTrue);
+    expect(testTraceState.size, equals(0));
+  });
+
+  test('put valid values', () {
+    final testTraceState = TraceState.empty()
+      ..put('key_0-1', 'value@2')
+      ..put('key_0-2', 'value@1')
+      ..put('key_@vendor', 'value@3');
+
+    expect(testTraceState.get('key_0-1'), equals('value@2'));
+    expect(testTraceState.get('key_0-2'), equals('value@1'));
+    expect(testTraceState.get('key_@vendor'), equals('value@3'));
+    expect(testTraceState.toString(),
+        equals('key_0-1=value@2,key_0-2=value@1,key_@vendor=value@3'));
+    expect(testTraceState.isEmpty, isFalse);
+    expect(testTraceState.size, equals(3));
+  });
+
+  test('create from string with invalid values', () {
+    final testTraceState = TraceState.fromString(
+        'key_0-1=0,value2,key&0-2=value@1,key_@thisisalotlongerthan13characters=value@3');
+
+    expect(testTraceState.get('key_0-1'), isNull); // Invalid value, comma.
+    expect(testTraceState.get('key&0-2'), isNull); // Invalid key.
+    expect(testTraceState.get('key_@thisisalotlongerthan13characters'),
+        isNull); // Invalid vendor key.
+    expect(testTraceState.toString(), equals(''));
+    expect(testTraceState.isEmpty, isTrue);
+    expect(testTraceState.size, equals(0));
+  });
+
+  test('put invalid values', () {
+    final testTraceState = TraceState.empty()
+      ..put('key_0-1', '0,value=2') // Invalid value.
+      ..put('key&0-2', 'value@1') // Invalid key.
+      ..put('key_@thisisalotlongerthan13characters',
+          'value@3'); // Invalid vendor key.
+
+    expect(testTraceState.get('key_0-1'), isNull);
+    expect(testTraceState.get('key_0-2'), isNull);
+    expect(testTraceState.get('key_@thisisalotlongerthan13characters'), isNull);
+    expect(testTraceState.toString(), equals(''));
+    expect(testTraceState.isEmpty, isTrue);
+    expect(testTraceState.size, equals(0));
+  });
+
+  test('key regex, valid key', () {
+    final matchResult = TraceState.validKeyRegex.matchAsPrefix('key_0-1');
+
+    expect(matchResult, isNotNull);
+    expect(matchResult.group(0), equals('key_0-1'));
+  });
+
+  test('key regex, valid vendor key', () {
+    final matchResult = TraceState.validKeyRegex.matchAsPrefix('key_@vendor');
+
+    expect(matchResult, isNotNull);
+    expect(matchResult.group(0), equals('key_@vendor'));
+  });
+
+  test('value regex, valid value', () {
+    final matchResult = TraceState.validValueRegex.matchAsPrefix('value@2');
+
+    expect(matchResult, isNotNull);
+    expect(matchResult.group(0), equals('value@2'));
+  });
+
+  test('key regex, invalid key', () {
+    final matchResult = TraceState.validKeyRegex.matchAsPrefix('key&0-2');
+
+    expect(matchResult, isNull);
+  });
+
+  test('key regex, invalid vendor key', () {
+    final matchResult = TraceState.validKeyRegex
+        .matchAsPrefix('key_@thisisalotlongerthan13characters');
+
+    expect(matchResult, isNull);
+  });
+
+  test('value regex, invalid value', () {
+    final matchResult = TraceState.validValueRegex.matchAsPrefix('0,value=2');
+
+    expect(matchResult, isNull);
+  });
+}


### PR DESCRIPTION
## Notes

This PR includes the following:
* A class `TextMapPropagator`, which defines generally the methods required to store and retrieve values between a Context and a carrier.
* A class `TextMapGetter`, which defines the methods required to retrive values from a carrier.
* A class `FContextExtractor`, which implements methods required to retrieve values from an FContext.
* A class `TextMapSetter`, which defines the methods required to store values onto a carrier.
* A class `FContextInjector`, which implements methods required to store values onto an FContext.
* A class `W3CTraceContextPropagator`, which implements the methods required to store and retrieve traces between a Context and a carrier via a W3C trace context header.
* Classes `TraceId` and `SpanId`, which store IDs for Spans and Traces, contain implementation to convert them to and from String format, and determine whether the ID they contain is valid.
* A class `TraceFlags`, which stores W3C trace flags for a Trace and provides methods to convert the flags to and from String format, determine whether a trace has been flagged for sampling, and determine whether the flags it contains are valid.
* A class `TraceState`, which stores additional state from W3C trace headers for a Trace and provides methods to convert the state to and from String format, store and retrieve data on the TraceState, determine the validitity of data on the TraceState.
* A class `NonRecordingSpan`, which wraps an incoming `Span` and allows storage on a `Context`.
* A class `NoopTracer`, which prevents a `NonRecordingSpan` from being able to be used to generate recording `Span`s.
* Updates in `Tracer`, `Span`, and `SpanContext` related to the addition of `TraceId`, `SpanId`, `TraceFlags`, and `TraceState`. 
* Properties to indication that a `Span` is "recording" data and should be sampled.  This is currently unused, but is recommended by the OpenTelemetry Specification and may prove useful as work on Exporters continues.
* Unit and Integration tests for the above.

## Recommended Reading

OpenTelemetry Specification, `TextMapPropagator`: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#textmap-propagator

W3C Traceparent Header, for `TraceId`, `SpanId`, and `TraceFlags`: https://www.w3.org/TR/trace-context/#traceparent-header

W3C Tracestate Header, for `TraceState`: https://www.w3.org/TR/trace-context/#tracestate-header

OpenTelemetry Specification, wrapping extracted `SpanContext` in a `Span` on `Context`: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#wrapping-a-spancontext-in-a-span

OpenTelemetry Specification, `isRecording` property for `Span`s: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#isrecording

## Reviewers

@tylersnavely-wf 
@Workiva/product-new-relic 