### PR TITLE
Bump pubspec.yaml version automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ update-package-version:  ## inject package version during build
 	if [ -n "${GIT_TAG}" ]; then \
 		echo "Setting package version to \"${GIT_TAG}\"" && \
 		sed -i.bak 's/static const String version = '\''0.0.0'\''/static const String version = ${GIT_TAG}/g' lib/src/sdk/instrumentation_library.dart && \
-		rm lib/src/sdk/instrumentation_library.dart.bak; \
+		rm lib/src/sdk/instrumentation_library.dart.bak && \
+		sed -i 's/version: 0.0.0/version: ${GIT_TAG}/g' pubspec.yaml; \
 	fi;
 
 .PHONY: init analyze test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: opentelemetry
-version: 0.0.2
+version: 0.0.0
 description: A framework for collecting traces from applications.
 homepage: https://github.com/Workiva/opentelemetry-dart
 publish_to: https://pub.workiva.org


### PR DESCRIPTION
On tagged build, we need to update our pubspec.yaml version in order to deploy to pub.workiva.org.