### PR TITLE
O11Y-1208: Set pubspec.yaml version automatically

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,6 @@ dependencies:
 
 dev_dependencies:
   meta: 1.6.0 # https://github.com/angulardart/angular/issues/1967
-  mockito: ^4.1.4  # TODO: Fix this.  Version 5.0.7 inompatible with Frugal.
+  mockito: ^4.1.4  # TODO: Fix this.  Version 5.0.7 incompatible with Frugal.
   test: ^1.16.5
   workiva_analysis_options: ^1.2.2


### PR DESCRIPTION
I've enabled the "Bump Version In Repo Via Direct Commit" step in rosie.  When this PR is merged, there _should_ be a direct commit from rosie to set the MARV version in pubspec.yaml.  We just need a PR associated with a release, so this fixes a typo.