### PR TITLE
O11Y-1208: Release every pull

### DIFF
--- a/lib/src/sdk/instrumentation_library.dart
+++ b/lib/src/sdk/instrumentation_library.dart
@@ -1,4 +1,4 @@
-import 'package:opentelemetry/src/api/instrumentation_library.dart' as api;
+import '../api/instrumentation_library.dart' as api;
 
 class InstrumentationLibrary implements api.InstrumentationLibrary {
   static const String name = 'opentelemetry-dart';


### PR DESCRIPTION
For real this time.  Releasing on every pull is enabled, and Rosie says
```
	When this pull is merged I will add it to the following release:
	Version: opentelemetry-dart 0.1.3
	Release Ticket(s): O11Y-1214

	This pull is considered the release of opentelemetry-dart 0.1.3 
	The options defined for this repo will be carried out
```