### PR TITLE
Pin protoc_plugin to 19.3.1 to account for SDK 2.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 init:
 	git submodule update --init
 	pub get
-	pub global activate protoc_plugin
+	pub global activate protoc_plugin 19.3.1
 	cd lib/src/sdk/trace/exporters && \
 		protoc --proto_path opentelemetry-proto \
 		--dart_out . \
@@ -11,8 +11,7 @@ init:
 		opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto
 
 analyze:
-	@dart analyze ./lib
-	@dart analyze ./test
+	@dart analyze
 
 format:
 	@find ./lib/ -name '*.dart' | xargs dart format --fix


### PR DESCRIPTION
```
Publishing opentelemetry 0.1.3 to https://pub.workiva.org:
|-- LICENSE
|-- README.md
|-- analysis_options.yaml
|-- lib
|   |-- api.dart
|   |-- sdk.dart
|   '-- src
|       |-- api
|       |   |-- common
|       |   |   |-- attribute.dart
|       |   |   '-- attributes.dart
|       |   |-- context
|       |   |   '-- context.dart
|       |   |-- instrumentation_library.dart
|       |   |-- propagation
|       |   |   |-- extractors
|       |   |   |   '-- text_map_getter.dart
|       |   |   |-- injectors
|       |   |   |   '-- text_map_setter.dart
|       |   |   '-- text_map_propagator.dart
|       |   '-- trace
|    ... (4537 more, please see e.stdout)
STDERR:
Package validation found the following errors:
* lib/src/sdk/trace/exporters/opentelemetry/proto/common/v1/common.pb.dart is declaring language version 2.12 that is newer than the SDK constraint 2.11 declared in `pubspec.yaml`.
* lib/src/sdk/trace/exporters/opentelemetry/proto/common/v1/common.pbenum.dart is declaring language version 2.12 that is newer than the SDK constraint 2.11 declared in `pubspec.yaml`.
* lib/src/sdk/trace/exporters/opentelemetry/proto/common/v1/common.pbjson.dart is declaring language version 2.12 that is newer than the SDK constraint 2.11 declared in `pubspec.yaml`.
* lib/src/sdk/trace/exporters/opentelemetry/proto/common/v1/common.pbserver.dart is declaring language version 2.12 that is newer than the SDK constrain... (2777 more, please see e.stderr)
Pub artifact upload failed for /artifacts/pub/build/pub_package.pub.tgz
Error: Not all artifacts could be pushed. Issue(s):
- Pub artifact upload failed for /artifacts/pub/build/pub_package.pub.tgz
```

Artifact upload to the pub server was failing because the proto generated code for dart is for version 2.12, but our app supports 2.11.  The latest version of the proto plugin for dart specifies a minimum version of 2.12, where version 19.3.1 allows a wider range (>=2.7.0 <3.0.0).

