### PR TITLE
O11Y-1190: Adding a Map inject and extract propagator

### DIFF
--- a/lib/sdk.dart
+++ b/lib/sdk.dart
@@ -1,5 +1,14 @@
 export 'src/sdk/trace/exporters/collector_exporter.dart' show CollectorExporter;
 export 'src/sdk/trace/exporters/console_exporter.dart' show ConsoleExporter;
+export 'src/sdk/trace/propagation/w3c_trace_context_propagator.dart'
+    show W3CTraceContextPropagator;
+export 'src/sdk/trace/propagation/injectors/fcontext_injector.dart'
+    show FContextInjector;
+export 'src/sdk/trace/propagation/injectors/map_injector.dart' show MapInjector;
+export 'src/sdk/trace/propagation/extractors/fcontext_extractor.dart'
+    show FContextExtractor;
+export 'src/sdk/trace/propagation/extractors/map_extractor.dart'
+    show MapExtractor;
 export 'src/sdk/trace/samplers/always_off_sampler.dart' show AlwaysOffSampler;
 export 'src/sdk/trace/samplers/always_on_sampler.dart' show AlwaysOnSampler;
 export 'src/sdk/trace/span_processors/batch_processor.dart'

--- a/lib/src/sdk/trace/propagation/extractors/map_extractor.dart
+++ b/lib/src/sdk/trace/propagation/extractors/map_extractor.dart
@@ -1,0 +1,13 @@
+import '../../../../api/propagation/extractors/text_map_getter.dart';
+
+class MapExtractor implements TextMapGetter<Map> {
+  @override
+  String get(Map carrier, String key) {
+    return (carrier == null) ? null : carrier[key];
+  }
+
+  @override
+  Iterable<String> keys(Map carrier) {
+    return carrier.keys;
+  }
+}

--- a/lib/src/sdk/trace/propagation/injectors/map_injector.dart
+++ b/lib/src/sdk/trace/propagation/injectors/map_injector.dart
@@ -1,0 +1,10 @@
+import '../../../../api/propagation/injectors/text_map_setter.dart';
+
+class MapInjector implements TextMapSetter<Map> {
+  @override
+  void set(Map carrier, String key, String value) {
+    if (carrier != null) {
+      carrier[key] = value;
+    }
+  }
+}

--- a/test/unit/sdk/propagation/map_propagation_test.dart
+++ b/test/unit/sdk/propagation/map_propagation_test.dart
@@ -1,0 +1,31 @@
+import 'package:opentelemetry/sdk.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('inject null carrier', () {
+    MapInjector().set(null, 'foo', 'bar');
+  });
+
+  test('inject carrier', () {
+    final map = {};
+    MapInjector().set(map, 'foo', 'bar');
+
+    expect(map['foo'], 'bar');
+  });
+
+  test('extract null carrier', () {
+    expect(MapExtractor().get(null, 'foo'), isNull);
+  });
+
+  test('extract carrier', () {
+    final map = {'foo': 'bar'};
+
+    expect(MapExtractor().get(map, 'foo'), 'bar');
+  });
+
+  test('extract keys', () {
+    final map = {'foo': 'bar', 'baz': 'qux'};
+
+    expect(MapExtractor().keys(map), ['foo', 'baz']);
+  });
+}


### PR DESCRIPTION
Adding Dart Map propagator so the appropriate headers can be injected and extracted using `payload.request.headers` in the HTTP interceptor in `wo11y-dart`.  This also exposes the FContext propgator and `W3CTraceContextPropagator` to the sdk so other libraries can use them.