### PR TITLE
Fix Version Make Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ update-package-version:  ## inject package version during build
 	@set -e; \
 	if [ -n "${GIT_TAG}" ]; then \
 		echo "Setting package version to \"${GIT_TAG}\"" && \
-		sed -i.bak 's/static const String version = '\''0.0.0'\''/static const String version = ${GIT_TAG}/g' lib/src/sdk/instrumentation_library.dart && \
+		sed -i.bak 's/static const String version = '\''0.0.0'\''/static const String version = '\''${GIT_TAG}'\''/g' lib/src/sdk/instrumentation_library.dart && \
 		rm lib/src/sdk/instrumentation_library.dart.bak; \
 	fi;
 


### PR DESCRIPTION
## Notes

This PR fixes an issue in the `update-package-version` make target which causes version information to be injected as a number instead of a string value.

## Reviewers

@Workiva/product-new-relic 