### PR TITLE
O11Y-1027: Parent Based Sampling

### DIFF
--- a/lib/src/api/trace/sampler.dart
+++ b/lib/src/api/trace/sampler.dart
@@ -1,13 +1,18 @@
+import '../common/attributes.dart';
 import '../context/context.dart';
-import '../instrumentation_library.dart';
 import 'sampling_result.dart';
 import 'span.dart';
+import 'trace_id.dart';
 
 /// Represents an entity which determines whether a [Span] should be sampled
 /// and sent for collection.
 abstract class Sampler {
   SamplingResult shouldSample(
-      Context context, Span span, InstrumentationLibrary library);
+      Context context,
+      TraceId traceId,
+      String spanName,
+      bool spanIsRemote, // ignore: avoid_positional_boolean_parameters
+      Attributes spanAttributes);
 
-  String get decision;
+  String get description;
 }

--- a/lib/src/api/trace/sampling_result.dart
+++ b/lib/src/api/trace/sampling_result.dart
@@ -1,3 +1,18 @@
+import '../common/attributes.dart';
+import 'trace_state.dart';
+
+enum Decision {
+  drop,
+  recordOnly,
+  recordAndSample,
+}
+
 /// Represents the result of a Sampler as to whether a Span should
 /// be processed for collection.
-abstract class SamplingResult {}
+abstract class SamplingResult {
+  final Decision decision;
+  final Attributes spanAttributes;
+  final TraceState traceState;
+
+  SamplingResult(this.decision, this.spanAttributes, this.traceState);
+}

--- a/lib/src/api/trace/span_context.dart
+++ b/lib/src/api/trace/span_context.dart
@@ -19,4 +19,8 @@ abstract class SpanContext {
   TraceState get traceState;
 
   bool get isValid;
+
+  /// Whether this SpanContext represents an operation which originated
+  /// from a remote source.
+  bool get isRemote;
 }

--- a/lib/src/sdk/trace/propagation/w3c_trace_context_propagator.dart
+++ b/lib/src/sdk/trace/propagation/w3c_trace_context_propagator.dart
@@ -57,7 +57,7 @@ class W3CTraceContextPropagator implements api.TextMapPropagator {
         : TraceState.empty();
 
     return context.withSpan(NonRecordingSpan(
-        SpanContext(traceId, parentId, traceFlags, traceState)));
+        SpanContext.remote(traceId, parentId, traceFlags, traceState)));
   }
 
   @override

--- a/lib/src/sdk/trace/samplers/always_off_sampler.dart
+++ b/lib/src/sdk/trace/samplers/always_off_sampler.dart
@@ -1,18 +1,20 @@
+import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
+
+import '../../../api/common/attributes.dart';
 import '../../../api/context/context.dart';
-import '../../../api/instrumentation_library.dart';
 import '../../../api/trace/sampler.dart' as api;
 import '../../../api/trace/sampling_result.dart' as result_api;
-import '../../../api/trace/span.dart' as span_api;
+import '../../../api/trace/trace_id.dart';
 import 'sampling_result.dart';
 
 class AlwaysOffSampler implements api.Sampler {
   @override
-  String get decision => 'AlwaysOffSampler';
+  String get description => 'AlwaysOffSampler';
 
   @override
-  result_api.SamplingResult shouldSample(Context context, span_api.Span span,
-      InstrumentationLibrary libraryVersion) {
-    return SamplingResult(
-        Decision.DROP, span.attributes, span.spanContext.traceState);
+  result_api.SamplingResult shouldSample(Context context, TraceId traceId,
+      String spanName, bool spanIsRemote, Attributes spanAttributes) {
+    return SamplingResult(result_api.Decision.drop, spanAttributes,
+        context.spanContext?.traceState ?? TraceState.empty());
   }
 }

--- a/lib/src/sdk/trace/samplers/always_on_sampler.dart
+++ b/lib/src/sdk/trace/samplers/always_on_sampler.dart
@@ -1,18 +1,19 @@
-import 'package:opentelemetry/src/api/context/context.dart';
-import 'package:opentelemetry/src/api/instrumentation_library.dart';
-import 'package:opentelemetry/src/api/trace/sampler.dart' as api;
-import 'package:opentelemetry/src/api/trace/sampling_result.dart' as result_api;
-import 'package:opentelemetry/src/api/trace/span.dart' as span_api;
-import 'package:opentelemetry/src/sdk/trace/samplers/sampling_result.dart';
+import '../../../api/common/attributes.dart';
+import '../../../api/context/context.dart';
+import '../../../api/trace/sampler.dart' as api;
+import '../../../api/trace/sampling_result.dart' as result_api;
+import '../../../api/trace/trace_id.dart';
+import '../trace_state.dart';
+import 'sampling_result.dart';
 
 class AlwaysOnSampler implements api.Sampler {
   @override
-  String get decision => 'AlwaysOnSampler';
+  String get description => 'AlwaysOnSampler';
 
   @override
-  result_api.SamplingResult shouldSample(
-      Context context, span_api.Span span, InstrumentationLibrary library) {
-    return SamplingResult(Decision.RECORD_AND_SAMPLE, span.attributes,
-        span.spanContext.traceState);
+  result_api.SamplingResult shouldSample(Context context, TraceId traceId,
+      String spanName, bool spanIsRemote, Attributes spanAttributes) {
+    return SamplingResult(result_api.Decision.recordAndSample, spanAttributes,
+        context.spanContext?.traceState ?? TraceState.empty());
   }
 }

--- a/lib/src/sdk/trace/samplers/parent_based_sampler.dart
+++ b/lib/src/sdk/trace/samplers/parent_based_sampler.dart
@@ -1,0 +1,52 @@
+import '../../../../sdk.dart';
+import '../../../api/common/attributes.dart' as api;
+import '../../../api/context/context.dart';
+import '../../../api/trace/sampler.dart';
+import '../../../api/trace/sampling_result.dart';
+import '../../../api/trace/trace_id.dart';
+
+class ParentBasedSampler implements Sampler {
+  final Sampler _root;
+  final Sampler _remoteParentSampled;
+  final Sampler _remoteParentNotSampled;
+  final Sampler _localParentSampled;
+  final Sampler _localParentNotSampled;
+
+  ParentBasedSampler(this._root,
+      {remoteParentSampled,
+      remoteParentNotSampled,
+      localParentSampled,
+      localParentNotSampled})
+      : _remoteParentSampled = remoteParentSampled ?? AlwaysOnSampler(),
+        _remoteParentNotSampled = remoteParentNotSampled ?? AlwaysOffSampler(),
+        _localParentSampled = localParentSampled ?? AlwaysOnSampler(),
+        _localParentNotSampled = localParentNotSampled ?? AlwaysOffSampler();
+
+  @override
+  String get description => 'ParentBasedSampler{root=${_root.description}}';
+
+  @override
+  SamplingResult shouldSample(Context context, TraceId traceId, String spanName,
+      bool spanIsRemote, api.Attributes spanAttributes) {
+    final parentSpanContext = context.spanContext;
+
+    if (parentSpanContext == null || !parentSpanContext.isValid) {
+      return _root.shouldSample(
+          context, traceId, spanName, spanIsRemote, spanAttributes);
+    }
+
+    if (parentSpanContext.isRemote) {
+      return (parentSpanContext.traceFlags.sampled)
+          ? _remoteParentSampled.shouldSample(
+              context, traceId, spanName, spanIsRemote, spanAttributes)
+          : _remoteParentNotSampled.shouldSample(
+              context, traceId, spanName, spanIsRemote, spanAttributes);
+    }
+
+    return (parentSpanContext.traceFlags.sampled)
+        ? _localParentSampled.shouldSample(
+            context, traceId, spanName, spanIsRemote, spanAttributes)
+        : _localParentNotSampled.shouldSample(
+            context, traceId, spanName, spanIsRemote, spanAttributes);
+  }
+}

--- a/lib/src/sdk/trace/samplers/sampling_result.dart
+++ b/lib/src/sdk/trace/samplers/sampling_result.dart
@@ -1,15 +1,12 @@
-import 'package:opentelemetry/api.dart';
-import 'package:opentelemetry/src/api/trace/sampling_result.dart' as api;
-
-enum Decision {
-  DROP,
-  RECORD_ONLY,
-  RECORD_AND_SAMPLE,
-}
+import '../../../../api.dart';
+import '../../../api/trace/sampling_result.dart' as api;
 
 class SamplingResult implements api.SamplingResult {
-  final Decision decision;
+  @override
+  final api.Decision decision;
+  @override
   final Attributes spanAttributes;
+  @override
   final TraceState traceState;
 
   SamplingResult(this.decision, this.spanAttributes, this.traceState);

--- a/lib/src/sdk/trace/span_context.dart
+++ b/lib/src/sdk/trace/span_context.dart
@@ -10,6 +10,7 @@ class SpanContext implements api.SpanContext {
   final TraceId _traceId;
   final TraceFlags _traceFlags;
   final TraceState _traceState;
+  final bool _isRemote;
 
   @override
   TraceId get traceId => _traceId;
@@ -27,9 +28,19 @@ class SpanContext implements api.SpanContext {
   bool get isValid => spanId.isValid && traceId.isValid;
 
   /// Construct a [SpanContext].
-  SpanContext(this._traceId, this._spanId, this._traceFlags, this._traceState);
+  SpanContext(this._traceId, this._spanId, this._traceFlags, this._traceState)
+      : _isRemote = false;
+
+  /// Construct a [SpanContext] representing an operation which originated
+  /// from a remote source.
+  SpanContext.remote(
+      this._traceId, this._spanId, this._traceFlags, this._traceState)
+      : _isRemote = true;
 
   /// Construct an invalid [SpanContext].
   factory SpanContext.invalid() => SpanContext(TraceId.invalid(),
       SpanId.invalid(), TraceFlags.invalid(), TraceState.empty());
+
+  @override
+  bool get isRemote => _isRemote;
 }

--- a/test/integration/sdk/tracer_test.dart
+++ b/test/integration/sdk/tracer_test.dart
@@ -2,14 +2,15 @@ import 'package:opentelemetry/src/api/context/context.dart';
 import 'package:opentelemetry/src/sdk/common/attributes.dart';
 import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
 import 'package:opentelemetry/src/sdk/resource/resource.dart';
-import 'package:opentelemetry/src/sdk/trace/tracer.dart';
 import 'package:opentelemetry/src/sdk/trace/id_generator.dart';
+import 'package:opentelemetry/src/sdk/trace/samplers/always_on_sampler.dart';
+import 'package:opentelemetry/src/sdk/trace/tracer.dart';
 import 'package:test/test.dart';
 
 void main() {
   test('startSpan new trace', () {
-    final tracer = Tracer([], Resource(Attributes.empty()), IdGenerator(),
-        InstrumentationLibrary('name', 'version'));
+    final tracer = Tracer([], Resource(Attributes.empty()), AlwaysOnSampler(),
+        IdGenerator(), InstrumentationLibrary('name', 'version'));
 
     final span = tracer.startSpan('foo');
 
@@ -20,8 +21,8 @@ void main() {
   });
 
   test('startSpan child span', () {
-    final tracer = Tracer([], Resource(Attributes.empty()), IdGenerator(),
-        InstrumentationLibrary('name', 'version'));
+    final tracer = Tracer([], Resource(Attributes.empty()), AlwaysOnSampler(),
+        IdGenerator(), InstrumentationLibrary('name', 'version'));
 
     final parentSpan = tracer.startSpan('foo');
     final context = Context.current.withSpan(parentSpan);

--- a/test/unit/sdk/propagation/w3c_trace_context_propagator_test.dart
+++ b/test/unit/sdk/propagation/w3c_trace_context_propagator_test.dart
@@ -1,6 +1,6 @@
 import 'package:opentelemetry/api.dart' as api;
-import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
 import 'package:opentelemetry/src/sdk/common/attributes.dart';
+import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
 import 'package:opentelemetry/src/sdk/resource/resource.dart';
 import 'package:opentelemetry/src/sdk/trace/propagation/w3c_trace_context_propagator.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';

--- a/test/unit/sdk/samplers/always_off_sampler_test.dart
+++ b/test/unit/sdk/samplers/always_off_sampler_test.dart
@@ -1,0 +1,55 @@
+import 'package:opentelemetry/sdk.dart';
+import 'package:opentelemetry/src/api/context/context.dart';
+import 'package:opentelemetry/src/api/trace/sampling_result.dart';
+import 'package:opentelemetry/src/api/trace/trace_flags.dart' as api;
+import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
+import 'package:opentelemetry/src/sdk/trace/span.dart';
+import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Context contains a Span', () {
+    final traceId = TraceId([1, 2, 3]);
+    final traceState = TraceState.fromString('test=onetwo');
+    final testSpan = Span(
+        'foo',
+        SpanContext(traceId, SpanId([7, 8, 9]), TraceFlags(api.TraceFlags.none),
+            traceState),
+        SpanId([4, 5, 6]),
+        [],
+        Resource(Attributes.empty()),
+        InstrumentationLibrary(
+            'always_off_sampler_test', 'sampler_test_version'));
+    final testContext = Context.current.withSpan(testSpan);
+
+    final result = AlwaysOffSampler().shouldSample(
+        testContext, traceId, testSpan.name, false, testSpan.attributes);
+
+    expect(result.decision, equals(Decision.drop));
+    expect(result.spanAttributes, same(testSpan.attributes));
+    expect(result.traceState, same(traceState));
+  });
+  test('Context does not contain a Span', () {
+    final traceId = TraceId([1, 2, 3]);
+    final testSpan = Span(
+        'foo',
+        SpanContext(traceId, SpanId([7, 8, 9]), TraceFlags(api.TraceFlags.none),
+            TraceState.empty()),
+        SpanId([4, 5, 6]),
+        [],
+        Resource(Attributes.empty()),
+        InstrumentationLibrary(
+            'always_off_sampler_test', 'sampler_test_version'));
+
+    final result = AlwaysOffSampler().shouldSample(
+        Context.root, traceId, testSpan.name, false, testSpan.attributes);
+
+    expect(result.decision, equals(Decision.drop));
+    expect(result.spanAttributes, same(testSpan.attributes));
+    expect(result.traceState.isEmpty, isTrue);
+  });
+}

--- a/test/unit/sdk/samplers/always_on_sampler_test.dart
+++ b/test/unit/sdk/samplers/always_on_sampler_test.dart
@@ -1,0 +1,55 @@
+import 'package:opentelemetry/sdk.dart';
+import 'package:opentelemetry/src/api/context/context.dart';
+import 'package:opentelemetry/src/api/trace/sampling_result.dart';
+import 'package:opentelemetry/src/api/trace/trace_flags.dart' as api;
+import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
+import 'package:opentelemetry/src/sdk/trace/span.dart';
+import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Context contains a Span', () {
+    final traceId = TraceId([1, 2, 3]);
+    final traceState = TraceState.fromString('test=onetwo');
+    final testSpan = Span(
+        'foo',
+        SpanContext(traceId, SpanId([7, 8, 9]), TraceFlags(api.TraceFlags.none),
+            traceState),
+        SpanId([4, 5, 6]),
+        [],
+        Resource(Attributes.empty()),
+        InstrumentationLibrary(
+            'always_on_sampler_test', 'sampler_test_version'));
+    final testContext = Context.current.withSpan(testSpan);
+
+    final result = AlwaysOnSampler().shouldSample(
+        testContext, traceId, testSpan.name, false, testSpan.attributes);
+
+    expect(result.decision, equals(Decision.recordAndSample));
+    expect(result.spanAttributes, same(testSpan.attributes));
+    expect(result.traceState, same(traceState));
+  });
+  test('Context does not contain a Span', () {
+    final traceId = TraceId([1, 2, 3]);
+    final testSpan = Span(
+        'foo',
+        SpanContext(traceId, SpanId([7, 8, 9]), TraceFlags(api.TraceFlags.none),
+            TraceState.empty()),
+        SpanId([4, 5, 6]),
+        [],
+        Resource(Attributes.empty()),
+        InstrumentationLibrary(
+            'always_on_sampler_test', 'sampler_test_version'));
+
+    final result = AlwaysOnSampler().shouldSample(
+        Context.root, traceId, testSpan.name, false, testSpan.attributes);
+
+    expect(result.decision, equals(Decision.recordAndSample));
+    expect(result.spanAttributes, same(testSpan.attributes));
+    expect(result.traceState.isEmpty, isTrue);
+  });
+}

--- a/test/unit/sdk/samplers/parent_based_sampler_test.dart
+++ b/test/unit/sdk/samplers/parent_based_sampler_test.dart
@@ -1,0 +1,144 @@
+import 'package:opentelemetry/sdk.dart';
+import 'package:opentelemetry/src/api/context/context.dart';
+import 'package:opentelemetry/src/api/trace/sampling_result.dart';
+import 'package:opentelemetry/src/api/trace/trace_flags.dart' as api;
+import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
+import 'package:opentelemetry/src/sdk/trace/samplers/parent_based_sampler.dart';
+import 'package:opentelemetry/src/sdk/trace/span.dart';
+import 'package:opentelemetry/src/sdk/trace/span_context.dart';
+import 'package:opentelemetry/src/sdk/trace/span_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_flags.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_id.dart';
+import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final onSampler = AlwaysOnSampler();
+  final offSampler = AlwaysOffSampler();
+  final testSampler = ParentBasedSampler(onSampler,
+      remoteParentSampled: onSampler,
+      remoteParentNotSampled: offSampler,
+      localParentSampled: onSampler,
+      localParentNotSampled: offSampler);
+  final traceId = TraceId([1, 2, 3]);
+
+  test('Invalid parent span context', () {
+    final testSpan = Span(
+        'test',
+        SpanContext.invalid(),
+        SpanId([4, 5, 6]),
+        [],
+        Resource(Attributes.empty()),
+        InstrumentationLibrary('parent_sampler_test', 'sampler_test_version'));
+
+    final testContext = Context.current.withSpan(testSpan);
+
+    final result = testSampler.shouldSample(
+        testContext, traceId, testSpan.name, false, testSpan.attributes);
+
+    expect(result.decision, equals(Decision.recordAndSample));
+    expect(result.spanAttributes, same(testSpan.attributes));
+    expect(result.traceState.isEmpty, isTrue);
+  });
+
+  test('Missing parent span context', () {
+    final testSpan = Span(
+        'test',
+        SpanContext.invalid(),
+        SpanId([4, 5, 6]),
+        [],
+        Resource(Attributes.empty()),
+        InstrumentationLibrary('parent_sampler_test', 'sampler_test_version'));
+
+    final result = testSampler.shouldSample(
+        Context.root, traceId, testSpan.name, false, testSpan.attributes);
+
+    expect(result.decision, equals(Decision.recordAndSample));
+    expect(result.spanAttributes, same(testSpan.attributes));
+    expect(result.traceState.isEmpty, isTrue);
+  });
+
+  test('with sampled, remote Span', () {
+    final traceId = TraceId([1, 2, 3]);
+    final traceState = TraceState.fromString('test=onetwo');
+    final testSpan = Span(
+        'foo',
+        SpanContext.remote(traceId, SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.sampledFlag), traceState),
+        SpanId([4, 5, 6]),
+        [],
+        Resource(Attributes.empty()),
+        InstrumentationLibrary('parent_sampler_test', 'sampler_test_version'));
+    final testContext = Context.current.withSpan(testSpan);
+
+    final result = testSampler.shouldSample(
+        testContext, traceId, testSpan.name, false, testSpan.attributes);
+
+    expect(result.decision, equals(Decision.recordAndSample));
+    expect(result.spanAttributes, same(testSpan.attributes));
+    expect(result.traceState, same(traceState));
+  });
+
+  test('with non-sampled, remote Span', () {
+    final traceId = TraceId([1, 2, 3]);
+    final traceState = TraceState.fromString('test=onetwo');
+    final testSpan = Span(
+        'foo',
+        SpanContext.remote(traceId, SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.none), traceState),
+        SpanId([4, 5, 6]),
+        [],
+        Resource(Attributes.empty()),
+        InstrumentationLibrary('parent_sampler_test', 'sampler_test_version'));
+    final testContext = Context.current.withSpan(testSpan);
+
+    final result = testSampler.shouldSample(
+        testContext, traceId, testSpan.name, false, testSpan.attributes);
+
+    expect(result.decision, equals(Decision.drop));
+    expect(result.spanAttributes, same(testSpan.attributes));
+    expect(result.traceState, same(traceState));
+  });
+
+  test('with sampled, local Span', () {
+    final traceId = TraceId([1, 2, 3]);
+    final traceState = TraceState.fromString('test=onetwo');
+    final testSpan = Span(
+        'foo',
+        SpanContext(traceId, SpanId([7, 8, 9]),
+            TraceFlags(api.TraceFlags.sampledFlag), traceState),
+        SpanId([4, 5, 6]),
+        [],
+        Resource(Attributes.empty()),
+        InstrumentationLibrary('parent_sampler_test', 'sampler_test_version'));
+    final testContext = Context.current.withSpan(testSpan);
+
+    final result = testSampler.shouldSample(
+        testContext, traceId, testSpan.name, false, testSpan.attributes);
+
+    expect(result.decision, equals(Decision.recordAndSample));
+    expect(result.spanAttributes, same(testSpan.attributes));
+    expect(result.traceState, same(traceState));
+  });
+
+  test('with non-sampled, local Span', () {
+    final traceId = TraceId([1, 2, 3]);
+    final traceState = TraceState.fromString('test=onetwo');
+    final testSpan = Span(
+        'foo',
+        SpanContext(traceId, SpanId([7, 8, 9]), TraceFlags(api.TraceFlags.none),
+            traceState),
+        SpanId([4, 5, 6]),
+        [],
+        Resource(Attributes.empty()),
+        InstrumentationLibrary('parent_sampler_test', 'sampler_test_version'));
+    final testContext = Context.current.withSpan(testSpan);
+
+    final result = testSampler.shouldSample(
+        testContext, traceId, testSpan.name, false, testSpan.attributes);
+
+    expect(result.decision, equals(Decision.drop));
+    expect(result.spanAttributes, same(testSpan.attributes));
+    expect(result.traceState, same(traceState));
+  });
+}


### PR DESCRIPTION
## Notes

This PR:

* Adds a Parent-Based Sampler.  Please see the "Recommended Reading" section for links to the specification for this sampler, descriptions regarding how it should operate, information about its defaults, and examples of its current implementation in Java, which this PR is modeled after.
* Makes changes in Tracer such that a Tracer will now rely upon its Sampler to determine whether a Span it creates should be sampled.  Please see the "Recommended Reading" section for links to examples of this process in the Java implementation, which this PR is modeled after.
* Makes changes in TracerProvider such that a Parent-Based Sampler is now the default Sampler for a Tracer as specified in the OpenTelemetry Specification.  Please see the "Recommended Reading" section for links to the relevant specification.
* Makes changes in SpanContext to allow differentiation between SpanContexts which were _created within_ the active service and those which were _propagated to_ the active service.  The Parent-Based Sampler uses this information when determining how to sample a particular Span.  Please see the "Recommended Reading" section for links to examples of this process in the Java implementation, which this PR is modeled after.
* Makes changes in the Sampler API to better align with the OpenTelemetry Specification for arguments to a Sampler.  Please see the "Recommended Reading" section for links to the relevant specification.

## Recommended Reading

* [OpenTelemetry Specification for Parent-Based Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#parentbased)
* [Parent-Based Sampler, Java Implementation](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSampler.java)
* [OpenTelemetry Specification for the Default Sampler.](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#built-in-samplers)
* [Use of a Sampler to determine whether to sample a Span when created by a Tracer, Java Implementation](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkSpanBuilder.java#L199)
* [Inclusion of "isRemote" Property in SpanContext, Java Implementation](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/trace/SpanContext.java#L157)
* [OpenTelemetry Specification for Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampler)

## Reviewers

@Workiva/product-new-relic 