### PR TITLE
Raise Max Versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   fixnum: ^0.10.0
   http: ^0.12.0
-  logging: ^0.11.4
+  logging: '>=0.11.4 <2.0.0'
   protobuf: ^1.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch raises the max versions allowed for the following
dependencies:
  - args <3.0.0
  - build <3.0.0
  - build_config <2.0.0
  - build_runner <3.0.0
  - checked_yaml <3.0.0
  - logging <2.0.0
  - pub_semver <3.0.0
  - pubspec_parse <2.0.0
  - uri <2.0.0

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/raise_max_versions`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/raise_max_versions)