### PR TITLE
Widen ranges of fixnum and protobuf

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  fixnum: ^0.10.0
+  fixnum: '>=0.10.0 <2.0.0'
   http: ^0.12.0
   logging: '>=0.11.4 <2.0.0'
-  protobuf: ^1.1.0
+  protobuf: '>=1.1.0 <3.0.0'
 
 dev_dependencies:
   mockito: ^5.0.7


### PR DESCRIPTION
Fixnum v1 and protobuf v2 are major releases, but only because they include the null-safety migration. This commit raises the maximum for these dependencies to unblock consumption of newer versions by downstream consumers.

This work is a part of [CPLAT's dependency upgrade](https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades) efforts.