### PR TITLE
Run semver report as part of CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG GIT_MERGE_HEAD
 ARG GIT_MERGE_BRANCH
 
 RUN pub global activate --hosted-url https://pub.workiva.org semver_audit ^2.2.0
-RUN pub global run semver_audit report --repo Workiva/opentelemetry
+RUN pub global run semver_audit report --repo Workiva/opentelemetry-dart
 
 ARG BUILD_ARTIFACTS_PUB=/build/pub_package.pub.tgz
 


### PR DESCRIPTION
As part of the CI process let's run the semver tooling that we have in place.

NOTE, this process will need to be re-visited once this is OSS'd