### PR TITLE
O11Y-1489: FrontEnd engineers need a way to visualize traces within the browser performance timeline

### DIFF
--- a/lib/src/api/span_processors/span_processor.dart
+++ b/lib/src/api/span_processors/span_processor.dart
@@ -1,7 +1,7 @@
 import '../../../api.dart' as api;
 
 abstract class SpanProcessor {
-  void onStart();
+  void onStart(api.Span span, api.Context context);
 
   void onEnd(api.Span span);
 

--- a/lib/src/sdk/platforms/web/trace/user_timing_processor.dart
+++ b/lib/src/sdk/platforms/web/trace/user_timing_processor.dart
@@ -1,0 +1,131 @@
+import 'dart:html' show window;
+import 'dart:math' show max, pow;
+
+import 'package:fixnum/fixnum.dart';
+
+import '../../../../../api.dart' as api;
+import '../../../../../sdk.dart' as sdk;
+import '../user_timing_filters/mark_measure_filter.dart';
+import '../user_timing_filters/window_measure_filter.dart';
+
+class UserTimingSpanProcessor implements api.SpanProcessor {
+  final api.SpanExporter _exporter;
+  bool _isShutdown = false;
+
+  // Cache these so they don't have to be recomputed.
+  // (most span IDs are Int64s, whose `toString` isn't the fastest)
+  String _markPrefix;
+  String _markStartName;
+  String _markEndName;
+
+  UserTimingSpanProcessor(this._exporter) {
+    initSpanFilter();
+  }
+
+  /// A tag used to specify a custom measure name for a [api.Span]
+  /// (the measure name default to [api.Span.name]).
+  ///
+  /// For instance, in the browser, this is the name that will be shown in the
+  /// "User Timing" section of a timeline profile.
+  ///
+  /// This is useful when you want to display additional information
+  /// for local debugging.
+  ///
+  ///     new Span('redraw_on', attributes: {
+  ///       'component.name': 'MyClass',
+  ///       devMeasureName: 'MyClass.redrawOn ($instanceCounter)',
+  ///     })
+  static const String devMeasureName = 'wk.dev.measure_name';
+
+  /// The measure name, which is what's shown in the "User Timing" section of a
+  /// browser dev tools timeline.
+  ///
+  /// Includes the name, spanId, and any references to other spans.
+  ///
+  /// If a consumer specifies a [devMeasureName] attribute, that will be used
+  /// instead of the name.
+  ///
+  /// Compute this on-demand instead of during initialization since consumers
+  /// may add attributes later in the span's lifetime.
+  String _measureName(span) =>
+      '${span.attributes.get(devMeasureName) ?? span.name}${_measureSuffix(span.spanContext.spanId, span.parentSpanId)}';
+
+  /// A suffix for the measure name that includes additional information for use
+  /// when debugging.
+  ///
+  /// Always include the span ID as a workaround for a bug where overlapping
+  /// measures with the same name are displayed incorrectly in the dev tools:
+  /// https://bugs.chromium.org/p/chromium/issues/detail?id=865780
+  String _measureSuffix(spanId, parentSpanId) =>
+      ' - ${_spanIdDebugString(spanId)}${_parentSpanDebugString(parentSpanId)}';
+
+  /// A short string representation of the referenced spans (including the
+  /// parentSpanId) for debugging purposes.
+  String _parentSpanDebugString(parentSpanId) {
+    return parentSpanId == null
+        ? ''
+        : '[childOf:${getSpanIdDebugString(parentSpanId)}]';
+  }
+
+  /// A short string representation of the span ID, for debugging purposes.
+  String _spanIdDebugString(spanId) => getSpanIdDebugString(spanId);
+
+  static const int _truncationLength = 3;
+  // Fancy version of for `parseInt('0x' + 'f' * _truncationLength)`
+  final int _truncationMask = pow(16, _truncationLength) - 1;
+
+  /// Returns the last 3 hexadecimal digits of [int64], padded with 0s.
+  ///
+  /// 3 digits is a good balance of preventing collisions and not being too long
+  /// when used in a measure name.
+  String _truncatedInt64(Int64 int64) => (int64 & _truncationMask)
+      .toHexString()
+      .toLowerCase()
+      .padLeft(_truncationLength, '0');
+
+  /// Returns a string representation of [spanId] for use in debugging,
+  /// truncated to 3 characters.
+  String getSpanIdDebugString(dynamic spanId) {
+    if (spanId is Int64) return _truncatedInt64(spanId);
+
+    const maxLength = 3;
+    final idString = spanId.toString();
+    // Take up to the last `maxLength` characters of the idString
+    return idString.substring(max(idString.length - maxLength, 0));
+  }
+
+  @override
+  void forceFlush() {}
+
+  @override
+  void onEnd(api.Span span) {
+    if (_isShutdown) {
+      return;
+    }
+
+    if (MarkMeasureFilter.doesSpanPassFilters(span)) {
+      window.performance.mark(_markEndName);
+      window.performance.measure(
+          _measureName(span as sdk.Span), _markStartName, _markEndName);
+    }
+
+    _exporter.export([span]);
+  }
+
+  @override
+  void onStart(api.Span span, api.Context context) {
+    if (MarkMeasureFilter.doesSpanPassFilters(span)) {
+      _markPrefix = '${span.name}[${span.spanContext.spanId}]';
+      _markStartName = '$_markPrefix.start';
+      _markEndName = '$_markPrefix.end';
+      window.performance.mark(_markStartName);
+    }
+  }
+
+  @override
+  void shutdown() {
+    forceFlush();
+    _isShutdown = true;
+    _exporter.shutdown();
+  }
+}

--- a/lib/src/sdk/platforms/web/user_timing_filters/mark_measure_filter.dart
+++ b/lib/src/sdk/platforms/web/user_timing_filters/mark_measure_filter.dart
@@ -1,0 +1,73 @@
+import 'package:meta/meta.dart';
+import '../../../../../api.dart' as api;
+
+/// The filter preference to use.
+///
+/// When using [allFilters], an empty rules list is always true.
+///
+/// When using [anyFilters], an empty rules list is always false.
+///
+/// Defaults to [allFilters].
+enum MarkMeasureFilterMode {
+  /// Spans that match any filter will be shown
+  anyFilters,
+
+  /// Spans that match all filters will be shown
+  allFilters,
+}
+
+/// Returns true if a span matches the rule.
+typedef MarkMeasureFilterRule = bool Function(api.Span span);
+
+/// A global class which can be configured to filter which spans appear in
+/// user timing metrics.
+class MarkMeasureFilter {
+  MarkMeasureFilterMode _filterMode = MarkMeasureFilterMode.allFilters;
+
+  MarkMeasureFilter._();
+
+  /// The [MarkMeasureFilterMode] currently being applied.
+  static MarkMeasureFilterMode get filterMode => _current._filterMode;
+
+  /// Assigns a new [MarkMeasureFilterMode].
+  static set filterMode(MarkMeasureFilterMode mode) {
+    _current._filterMode = mode;
+  }
+
+  /// Adds a new [MarkMeasureFilterRule] to the filter
+  static void addFilter(MarkMeasureFilterRule rule) => _current._addRule(rule);
+
+  /// Clears out all [MarkMeasureFilterRule]s.
+  static void clearFilters() => _current._clearRules();
+
+  /// Returns true if the span meets the requirements of the current [MarkMeasureFilterMode].
+  static bool doesSpanPassFilters(api.Span span) =>
+      _current._doesSpanPassFilters(span);
+
+  static final MarkMeasureFilter _current = MarkMeasureFilter._();
+
+  @visibleForTesting
+  static List<MarkMeasureFilterRule> get rules => _current._rules;
+
+  final List<MarkMeasureFilterRule> _rules = [];
+  void _addRule(MarkMeasureFilterRule rule) => _rules.add(rule);
+  void _clearRules() => _rules.clear();
+
+  bool _doesSpanPassFilters(api.Span span) {
+    switch (filterMode) {
+      case MarkMeasureFilterMode.allFilters:
+        return _doAllFiltersApplyToSpan(span);
+      case MarkMeasureFilterMode.anyFilters:
+        return _doAnyFiltersApplyToSpan(span);
+    }
+
+    // Not possible; just to make Analyzer happy
+    return false;
+  }
+
+  bool _doAllFiltersApplyToSpan(api.Span span) =>
+      _rules.every((rule) => rule(span));
+
+  bool _doAnyFiltersApplyToSpan(api.Span span) =>
+      _rules.any((rule) => rule(span));
+}

--- a/lib/src/sdk/platforms/web/user_timing_filters/window_measure_filter.dart
+++ b/lib/src/sdk/platforms/web/user_timing_filters/window_measure_filter.dart
@@ -1,0 +1,108 @@
+@JS()
+library window_measure_filter;
+
+import 'dart:js_util';
+
+import 'package:js/js.dart';
+
+import '../../../../../api.dart' as api;
+import '../../../../../sdk.dart' as sdk;
+import 'mark_measure_filter.dart';
+
+typedef CustomFilter = bool Function(dynamic span);
+
+@anonymous
+@JS()
+class MarkMeasureFilterJS {
+  external factory MarkMeasureFilterJS({
+    Function addCustomFilter,
+    Function addNameFilter,
+    Function addAttributeFilter,
+    Function addAttributeKeyFilter,
+    Function clearFilters,
+    Function showMeasuresMatchingAnyFilters,
+    Function showMeasuresMatchingAllFilters,
+  });
+
+  external void addCustomFilter(CustomFilter filter);
+  external void addNameFilter(String rule);
+  external void addAttributeFilter(String key, String value);
+  external void addAttributeKeyFilter(String key);
+
+  external void clearFilters();
+
+  external void showMeasuresMatchingAnyFilters();
+  external void showMeasuresMatchingAllFilters();
+}
+
+@JS()
+external set $spanFilter(MarkMeasureFilterJS v);
+@JS()
+external MarkMeasureFilterJS get $spanFilter;
+
+Map jsonifyContext(api.SpanContext context) => {
+      'spanId': context.spanId.toString(),
+      'traceId': context.traceId.toString(),
+      'traceFlags': context.traceFlags,
+      'traceState': context.traceState,
+      'isValid': context.isValid,
+      'isRemote': context.isRemote,
+    };
+
+Map jsonifyInstrumentationLibrary(
+        api.InstrumentationLibrary instrumentationLibrary) =>
+    {
+      'name': instrumentationLibrary.name,
+      'version': instrumentationLibrary.version,
+    };
+
+Map jsonifySpan(sdk.Span span) => {
+      'spanContext':
+          span.spanContext != null ? jsonifyContext(span.spanContext) : null,
+      'parentSpanId': span.parentSpanId?.toString(),
+      'name': span.name,
+      'startTime': span.startTime,
+      'endTime': span.endTime,
+      'attributes': span.attributes,
+      'isRecording': span.isRecording,
+      'kind': span.kind,
+      'status': span.status,
+      'resource': span.resource,
+      'instrumentationLibrary': span.instrumentationLibrary != null
+          ? jsonifyInstrumentationLibrary(span.instrumentationLibrary)
+          : null,
+    };
+
+void initSpanFilter() {
+  $spanFilter ??= MarkMeasureFilterJS(
+    addCustomFilter: allowInterop((customFilter) {
+      MarkMeasureFilter.addFilter(
+          (span) => customFilter(jsify(jsonifySpan(span as sdk.Span))));
+      print('Added custom filter');
+    }),
+    addNameFilter: allowInterop((rule) {
+      MarkMeasureFilter.addFilter((span) => span.name.contains(rule));
+      print('Added rule: `span.name.contains($rule)`');
+    }),
+    addAttributeKeyFilter: allowInterop((key) {
+      MarkMeasureFilter.addFilter(
+          (span) => (span as sdk.Span).attributes.get(key) != null);
+      print('Added rule: `span.attributes.containsKey($key)`');
+    }),
+    addAttributeFilter: allowInterop((key, value) {
+      MarkMeasureFilter.addFilter((span) =>
+          (span as sdk.Span).attributes.get(key).toString().contains(value));
+      print(
+          'Added rule: `span.attributes.get(`$key`).toString().contains(`$value`)');
+    }),
+    showMeasuresMatchingAllFilters: allowInterop(() {
+      MarkMeasureFilter.filterMode = MarkMeasureFilterMode.allFilters;
+      print('Filtering spans that match all filters');
+    }),
+    showMeasuresMatchingAnyFilters: allowInterop(() {
+      MarkMeasureFilter.filterMode = MarkMeasureFilterMode.anyFilters;
+      print('Filtering spans that match any filters');
+    }),
+    clearFilters: allowInterop(MarkMeasureFilter.clearFilters),
+  );
+}

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -6,6 +6,7 @@ import '../common/attributes.dart';
 
 /// A representation of a single operation within a trace.
 class Span implements api.Span {
+  final api.Context _context;
   final api.SpanContext _spanContext;
   final api.SpanId _parentSpanId;
   final api.SpanKind _kind; // ignore: unused_field
@@ -30,12 +31,14 @@ class Span implements api.Span {
   /// Construct a [Span].
   Span(this.name, this._spanContext, this._parentSpanId, this._processors,
       this._timeProvider, this._resource, this._instrumentationLibrary,
-      {api.SpanKind kind,
+      {api.Context context,
+      api.SpanKind kind,
       List<api.Attribute> attributes,
       List<api.SpanLink> links,
       sdk.SpanLimits spanlimits,
       Int64 startTime})
-      : _links = links ?? [],
+      : _context = context,
+        _links = links ?? [],
         _kind = kind ?? api.SpanKind.internal,
         _startTime = startTime ?? _timeProvider.now,
         _spanLimits = spanlimits ?? sdk.SpanLimits() {
@@ -44,7 +47,7 @@ class Span implements api.Span {
     }
 
     for (var i = 0; i < _processors.length; i++) {
-      _processors[i].onStart();
+      _processors[i].onStart(this, _context);
     }
   }
 

--- a/lib/src/sdk/trace/span_processors/batch_processor.dart
+++ b/lib/src/sdk/trace/span_processors/batch_processor.dart
@@ -46,7 +46,7 @@ class BatchSpanProcessor implements api.SpanProcessor {
   }
 
   @override
-  void onStart() {}
+  void onStart(api.Span span, api.Context context) {}
 
   @override
   void shutdown() {

--- a/lib/src/sdk/trace/span_processors/simple_processor.dart
+++ b/lib/src/sdk/trace/span_processors/simple_processor.dart
@@ -19,7 +19,7 @@ class SimpleSpanProcessor implements api.SpanProcessor {
   }
 
   @override
-  void onStart() {}
+  void onStart(api.Span span, api.Context context) {}
 
   @override
   void shutdown() {

--- a/lib/src/sdk/trace/tracer.dart
+++ b/lib/src/sdk/trace/tracer.dart
@@ -58,6 +58,7 @@ class Tracer implements api.Tracer {
 
     return Span(name, spanContext, parentSpanId, _processors, _timeProvider,
         _resource, _instrumentationLibrary,
+        context: context,
         kind: kind,
         attributes: attributes,
         links: links,

--- a/lib/web_sdk.dart
+++ b/lib/web_sdk.dart
@@ -2,3 +2,5 @@ export 'src/sdk/platforms/web/time_providers/web_time_provider.dart'
     show WebTimeProvider;
 export 'src/sdk/platforms/web/trace/web_tracer_provider.dart'
     show WebTracerProvider;
+export 'src/sdk/platforms/web/trace/user_timing_processor.dart'
+    show UserTimingSpanProcessor;

--- a/test/integration/sdk/span_test.dart
+++ b/test/integration/sdk/span_test.dart
@@ -27,8 +27,8 @@ void main() {
     expect(span.parentSpanId, same(parentSpanId));
     expect(span.name, 'foo');
 
-    verify(mockProcessor1.onStart()).called(1);
-    verify(mockProcessor2.onStart()).called(1);
+    verify(mockProcessor1.onStart(span, null)).called(1);
+    verify(mockProcessor2.onStart(span, null)).called(1);
     verifyNever(mockProcessor1.onEnd(span));
     verifyNever(mockProcessor2.onEnd(span));
 

--- a/test/unit/sdk/platforms/web/mark_measure_filter_test.dart
+++ b/test/unit/sdk/platforms/web/mark_measure_filter_test.dart
@@ -1,0 +1,135 @@
+@TestOn('chrome')
+import 'package:opentelemetry/api.dart' as api;
+import 'package:opentelemetry/sdk.dart' as sdk;
+import 'package:test/test.dart';
+
+import 'package:opentelemetry/src/sdk/platforms/web/user_timing_filters/mark_measure_filter.dart';
+
+void main() {
+  group('MarkMeasureFilter', () {
+    const testSpanName = 'test_span';
+    const testSpanAttributeKey = 'test_attribute';
+    const testSpanAttributeValue = 'test_attribute_value';
+    final testSpanAttributes = [
+      api.Attribute.fromString(testSpanAttributeKey, testSpanAttributeValue)
+    ];
+
+    final testSpan = sdk.Span(
+        testSpanName,
+        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanId([4, 5, 6]),
+        <api.SpanProcessor>[],
+        sdk.DateTimeTimeProvider(),
+        sdk.Resource([]),
+        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        attributes: testSpanAttributes);
+
+    bool passingNameTest(api.Span span) => span.name == testSpanName;
+    bool failingNameTest(api.Span span) => span.name == 'something_else';
+    bool passingAttributeTest(api.Span span) =>
+        (span as sdk.Span).attributes.get(testSpanAttributeKey) != null;
+    bool failingAttributeTest(api.Span span) =>
+        (span as sdk.Span).attributes.get('something_else') != null;
+
+    tearDown(() {
+      MarkMeasureFilter.clearFilters();
+      assert(MarkMeasureFilter.rules.isEmpty,
+          'Filter rules must be cleared between tests');
+    });
+
+    group('with FilterMode.allFilter', () {
+      setUp(() {
+        MarkMeasureFilter.filterMode = MarkMeasureFilterMode.allFilters;
+      });
+
+      test('with no rules always passes', () {
+        expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isTrue);
+      });
+
+      group('with one test', () {
+        test('passes if the test passes', () {
+          MarkMeasureFilter.addFilter(passingNameTest);
+
+          expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isTrue);
+        });
+
+        test('fails if the test fails', () {
+          MarkMeasureFilter.addFilter(failingNameTest);
+
+          expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isFalse);
+        });
+      });
+
+      group('with several tests', () {
+        test('passes if all tests pass', () {
+          MarkMeasureFilter.addFilter(passingNameTest);
+          MarkMeasureFilter.addFilter(passingAttributeTest);
+
+          expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isTrue);
+        });
+
+        test('fails if one test fails', () {
+          MarkMeasureFilter.addFilter(passingNameTest);
+          MarkMeasureFilter.addFilter(failingAttributeTest);
+
+          expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isFalse);
+        });
+
+        test('fails if all tests fail', () {
+          MarkMeasureFilter.addFilter(failingNameTest);
+          MarkMeasureFilter.addFilter(failingAttributeTest);
+
+          expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isFalse);
+        });
+      });
+    });
+
+    group('with FilterMode.anyFilter', () {
+      setUp(() {
+        MarkMeasureFilter.filterMode = MarkMeasureFilterMode.anyFilters;
+      });
+
+      test('with no rules always fails', () {
+        expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isFalse);
+      });
+
+      group('with one test', () {
+        test('passes if the test passes', () {
+          MarkMeasureFilter.addFilter(passingNameTest);
+
+          expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isTrue);
+        });
+
+        test('fails if the test fails', () {
+          MarkMeasureFilter.addFilter(failingNameTest);
+
+          expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isFalse);
+        });
+      });
+
+      group('with several tests', () {
+        test('passes if all tests pass', () {
+          MarkMeasureFilter.addFilter(passingNameTest);
+          MarkMeasureFilter.addFilter(passingAttributeTest);
+
+          expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isTrue);
+        });
+
+        test('passes if one test passes', () {
+          MarkMeasureFilter.addFilter(failingNameTest);
+          MarkMeasureFilter.addFilter(passingAttributeTest);
+
+          expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isTrue);
+        });
+
+        test('fails if all tests fail', () {
+          MarkMeasureFilter.addFilter(failingNameTest);
+          MarkMeasureFilter.addFilter(failingAttributeTest);
+
+          expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isFalse);
+        });
+      });
+    });
+  });
+}

--- a/test/unit/sdk/platforms/web/user_timing_processor_test.dart
+++ b/test/unit/sdk/platforms/web/user_timing_processor_test.dart
@@ -1,0 +1,84 @@
+@TestOn('chrome')
+import 'dart:html' show PerformanceEntry, window;
+import 'package:mockito/mockito.dart';
+import 'package:opentelemetry/api.dart' as api;
+import 'package:opentelemetry/sdk.dart' as sdk;
+import 'package:opentelemetry/src/api/exporters/span_exporter.dart';
+import 'package:opentelemetry/src/api/trace/span.dart';
+import 'package:opentelemetry/src/sdk/platforms/web/trace/user_timing_processor.dart';
+import 'package:test/test.dart';
+
+import '../../../mocks.dart';
+
+void main() {
+  SpanExporter exporter;
+  UserTimingSpanProcessor processor;
+  Span span;
+  const testSpanName = 'test_span';
+  const testSpanAttributeKey = 'test_attribute';
+  const testSpanAttributeValue = 'test_attribute_value';
+  final testSpanAttributes = [
+    api.Attribute.fromString(testSpanAttributeKey, testSpanAttributeValue)
+  ];
+
+  setUp(() {
+    exporter = MockSpanExporter();
+    processor = UserTimingSpanProcessor(exporter);
+    span = sdk.Span(
+        testSpanName,
+        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanId([4, 5, 6]),
+        <api.SpanProcessor>[processor],
+        sdk.DateTimeTimeProvider(),
+        sdk.Resource([]),
+        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        attributes: testSpanAttributes);
+  });
+
+  test('sets marks and measure', () {
+    var marks = List<PerformanceEntry>.from(
+        window.performance.getEntriesByType('mark'));
+    var measures = List<PerformanceEntry>.from(
+        window.performance.getEntriesByType('measure'));
+    expect(marks, hasLength(1));
+    expect(marks[0].name, 'test_span[070809].start');
+    expect(measures, hasLength(0));
+
+    processor.onEnd(span);
+
+    marks = List<PerformanceEntry>.from(
+        window.performance.getEntriesByType('mark'));
+    measures = List<PerformanceEntry>.from(
+        window.performance.getEntriesByType('measure'));
+    expect(marks, hasLength(2));
+    expect(marks[1].name, 'test_span[070809].end');
+    expect(measures, hasLength(1));
+    expect(measures[0].name, 'test_span - 809[childOf:506]');
+  });
+
+  test('devMeasureName changes measure name', () {
+    span.setAttribute(
+        api.Attribute.fromString('wk.dev.measure_name', 'devMeasureNameTest'));
+    processor.onEnd(span);
+
+    final measures = List<PerformanceEntry>.from(window.performance
+        .getEntriesByName('devMeasureNameTest - 809[childOf:506]', 'measure'));
+    expect(measures, hasLength(1));
+  });
+
+  test('executes export', () {
+    processor.onEnd(span);
+
+    verify(exporter.export([span])).called(1);
+  });
+
+  test('does not export if shutdown', () {
+    processor
+      ..shutdown()
+      ..onEnd(span);
+
+    verify(exporter.shutdown()).called(1);
+    verifyNever(exporter.export([span]));
+  });
+}

--- a/test/unit/sdk/platforms/web/window_measure_filter_test.dart
+++ b/test/unit/sdk/platforms/web/window_measure_filter_test.dart
@@ -1,0 +1,86 @@
+@TestOn('chrome')
+import 'dart:js_util';
+
+import 'package:js/js.dart';
+import 'package:test/test.dart';
+
+import 'package:opentelemetry/api.dart' as api;
+import 'package:opentelemetry/sdk.dart' as sdk;
+import 'package:opentelemetry/src/sdk/platforms/web/user_timing_filters/mark_measure_filter.dart';
+import 'package:opentelemetry/src/sdk/platforms/web/user_timing_filters/window_measure_filter.dart';
+
+void main() {
+  group('MarkMeasureFilterJS', () {
+    const testSpanName = 'test_span';
+    const testSpanAttributeKey = 'test_attribute';
+    const testSpanAttributeValue = 'test_attribute_value';
+    final testSpanAttributes = [
+      api.Attribute.fromString(testSpanAttributeKey, testSpanAttributeValue)
+    ];
+
+    final testSpan = sdk.Span(
+        testSpanName,
+        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanId([4, 5, 6]),
+        <api.SpanProcessor>[],
+        sdk.DateTimeTimeProvider(),
+        sdk.Resource([]),
+        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        attributes: testSpanAttributes)
+      ..end();
+
+    setUp(() {
+      initSpanFilter();
+
+      // Set to any because this fails if there are no rules
+      // This makes it much easer to test that individual rules are being added
+      MarkMeasureFilter.filterMode = MarkMeasureFilterMode.anyFilters;
+    });
+
+    tearDown(() {
+      MarkMeasureFilter.clearFilters();
+      assert(MarkMeasureFilter.rules.isEmpty,
+          'Filter rules must be cleared between tests');
+    });
+
+    test('addNameFilter adds filter', () {
+      $spanFilter.addNameFilter(testSpanName);
+      expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isTrue);
+    });
+
+    test('addAttributeKeyFilter adds filter', () {
+      $spanFilter.addAttributeKeyFilter(testSpanAttributeKey);
+      expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isTrue);
+    });
+
+    test('addAttributeFilter adds filter', () {
+      $spanFilter.addAttributeFilter(
+          testSpanAttributeKey, testSpanAttributeValue);
+      expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isTrue);
+    });
+
+    test('addCustomFilter adds filter', () {
+      $spanFilter.addCustomFilter(
+        allowInterop((span) => getProperty(span, 'name') != testSpanName),
+      );
+      expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isFalse);
+    });
+
+    test('clearFilters clears filters', () {
+      $spanFilter.addNameFilter(testSpanName);
+      expect(MarkMeasureFilter.doesSpanPassFilters(testSpan), isTrue);
+
+      $spanFilter.clearFilters();
+      expect(MarkMeasureFilter.rules.isEmpty, isTrue);
+    });
+
+    test('showMeasuresMatching***Filters sets FilterMode', () {
+      expect(MarkMeasureFilter.filterMode, MarkMeasureFilterMode.anyFilters);
+      $spanFilter.showMeasuresMatchingAllFilters();
+      expect(MarkMeasureFilter.filterMode, MarkMeasureFilterMode.allFilters);
+      $spanFilter.showMeasuresMatchingAnyFilters();
+      expect(MarkMeasureFilter.filterMode, MarkMeasureFilterMode.anyFilters);
+    });
+  });
+}


### PR DESCRIPTION
https://jira.atl.workiva.net/browse/O11Y-1489

This PR adds a WebTracerProvider, WebTracer, and WebSpan that accepts a useUserTiming boolean which determines if spans show up in the browser performance timeline.