### PR TITLE
O11Y-1716 : add skynet.yaml

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,0 +1,10 @@
+name: opentelemetry-dart
+contact: "Slack: #support-observability"
+description: Placeholder test to be updated prior to 1.0 release.
+run:
+  when-branch-name-is:
+    - .+
+size: small
+timeout: 300
+scripts:
+  - 'true'


### PR DESCRIPTION
This adds a no-op skynet integration test as a placeholder. This is necessary to get library releases going again. We plan on coming back around and implementing legitimate integration tests in the future.

@Workiva/product-new-relic 