### PR TITLE
Replace deprecated commands with new dart commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 RUN apt update && apt install -y make protobuf-compiler
 
 COPY pubspec.yaml .
-RUN pub get
+RUN dart pub get
 
 COPY . .
 
@@ -24,8 +24,8 @@ ARG GIT_HEAD_URL
 ARG GIT_MERGE_HEAD
 ARG GIT_MERGE_BRANCH
 
-RUN pub global activate --hosted-url https://pub.workiva.org semver_audit ^2.2.0
-RUN pub global run semver_audit report --repo Workiva/opentelemetry-dart
+RUN dart pub global activate --hosted-url https://pub.workiva.org semver_audit ^2.2.0
+RUN dart pub global run semver_audit report --repo Workiva/opentelemetry-dart
 
 ARG BUILD_ARTIFACTS_PUB=/build/pub_package.pub.tgz
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 init:
 	git submodule update --init
-	pub get
-	pub global activate protoc_plugin 19.3.1
+	dart pub get
+	dart pub global activate protoc_plugin 19.3.1
 	cd lib/src/sdk/trace/exporters && \
 		protoc --proto_path opentelemetry-proto \
 		--dart_out . \


### PR DESCRIPTION
This Sourcegraph batch replaces deprecated commands from the Dart SDK with the new ones.
All new CLI commands now live under the main `dart` executable. See this issue for the details
https://github.com/dart-lang/sdk/issues/46100

This PR might need to be checked or tweaked for possible errors in the arguments to 
`dart analyze` and `dart format` since they take slightly different arguments than the original.
In most cases for analyze all the arguments can be removed and it can just be `dart analyze`.

Some of the argument changes were difficult to match and replace in an automated way. Since
there are only a few places that might break, it'll be easier to let the batch create the PR
and then manually adjust them.

### Argument changes for dartfmt -> dart format
`-w` should be removed automatically since overwriting files is now the default. But, if you spot one, remove it.
`--dry-run` is not a supported argument now. Replace with `--set-exit-if-changed -o none`

repos that look like they will need updates for dart format
- abide
- abide_archived
- bender.dart
- unscripted (unused repo)

### Argument changes for dartanalyzer -> dart analyze
`--no-hints` and `--no-lints` are removed

repos that look like they will need updates for dart analyze
- user_analytics


### QA steps:

- CI passing is a great start since these commands are usually called in the dockerfile, shell scripts, or skynet
- Check the changeset and if there are scripts that are only run locally and not in CI, try running them locally to verify they work
- If the PR has changes to `dart analyze` or `dart format` check the arguments
- Lastly, look for replacements that matched in the wrong place and should be undone or fixed

[_Created by Sourcegraph batch change `Workiva/dart_commands`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_commands)