### PR TITLE
O11Y-1749: OpenTelemetry Dart: Complete Implementation of SpanKind

### DIFF
--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -2,7 +2,22 @@ import 'package:fixnum/fixnum.dart';
 
 import '../../../api.dart' as api;
 
-enum SpanKind { server, client, producer, consumer, internal }
+enum SpanKind {
+  /// Server-side handling of a synchronous RPC or other remote request.
+  server,
+
+  /// A request to a remote service.
+  client,
+
+  /// An initiator of an asynchronous request.
+  producer,
+
+  /// A handler of an asynchronous producer request.
+  consumer,
+
+  /// An internal operation within an application, as opposed to an operation with remote parents or children.
+  internal
+}
 
 /// A representation of a single operation within a trace.
 ///

--- a/lib/src/sdk/trace/exporters/collector_exporter.dart
+++ b/lib/src/sdk/trace/exporters/collector_exporter.dart
@@ -89,6 +89,27 @@ class CollectorExporter implements api.SpanExporter {
         break;
     }
 
+    pb_trace.Span_SpanKind spanKind;
+    switch (span.kind) {
+      case api.SpanKind.client:
+        spanKind = pb_trace.Span_SpanKind.SPAN_KIND_CLIENT;
+        break;
+      case api.SpanKind.consumer:
+        spanKind = pb_trace.Span_SpanKind.SPAN_KIND_CONSUMER;
+        break;
+      case api.SpanKind.internal:
+        spanKind = pb_trace.Span_SpanKind.SPAN_KIND_INTERNAL;
+        break;
+      case api.SpanKind.producer:
+        spanKind = pb_trace.Span_SpanKind.SPAN_KIND_PRODUCER;
+        break;
+      case api.SpanKind.server:
+        spanKind = pb_trace.Span_SpanKind.SPAN_KIND_SERVER;
+        break;
+      default:
+        spanKind = pb_trace.Span_SpanKind.SPAN_KIND_UNSPECIFIED;
+    }
+
     return pb_trace.Span(
         traceId: span.spanContext.traceId.get(),
         spanId: span.spanContext.spanId.get(),
@@ -99,8 +120,9 @@ class CollectorExporter implements api.SpanExporter {
         attributes: span.attributes.keys.map((key) => pb_common.KeyValue(
             key: key,
             value: _attributeValueToProtobuf(span.attributes.get(key)))),
-        status: pb_trace.Status(
-            code: statusCode, message: span.status.description));
+        status:
+            pb_trace.Status(code: statusCode, message: span.status.description),
+        kind: spanKind);
   }
 
   pb_common.AnyValue _attributeValueToProtobuf(Object value) {

--- a/lib/src/sdk/trace/sampling/always_off_sampler.dart
+++ b/lib/src/sdk/trace/sampling/always_off_sampler.dart
@@ -11,7 +11,6 @@ class AlwaysOffSampler implements sdk.Sampler {
       api.TraceId traceId,
       String spanName,
       api.SpanKind spanKind,
-      bool spanIsRemote,
       List<api.Attribute> spanAttributes,
       List<api.SpanLink> links) {
     return sdk.SamplingResult(sdk.Decision.drop, spanAttributes,

--- a/lib/src/sdk/trace/sampling/always_on_sampler.dart
+++ b/lib/src/sdk/trace/sampling/always_on_sampler.dart
@@ -11,7 +11,6 @@ class AlwaysOnSampler implements sdk.Sampler {
       api.TraceId traceId,
       String spanName,
       api.SpanKind spanKind,
-      bool spanIsRemote,
       List<api.Attribute> spanAttributes,
       List<api.SpanLink> spanLinks) {
     return sdk.SamplingResult(sdk.Decision.recordAndSample, spanAttributes,

--- a/lib/src/sdk/trace/sampling/parent_based_sampler.dart
+++ b/lib/src/sdk/trace/sampling/parent_based_sampler.dart
@@ -29,30 +29,29 @@ class ParentBasedSampler implements sdk.Sampler {
       api.TraceId traceId,
       String spanName,
       api.SpanKind spanKind,
-      bool spanIsRemote,
       List<api.Attribute> spanAttributes,
       List<api.SpanLink> spanLinks) {
     final parentSpanContext = context.spanContext;
 
     if (parentSpanContext == null || !parentSpanContext.isValid) {
-      return _root.shouldSample(context, traceId, spanName, spanKind,
-          spanIsRemote, spanAttributes, spanLinks);
+      return _root.shouldSample(
+          context, traceId, spanName, spanKind, spanAttributes, spanLinks);
     }
 
     if (parentSpanContext.isRemote) {
       return ((parentSpanContext.traceFlags & api.TraceFlags.sampled) ==
               api.TraceFlags.sampled)
-          ? _remoteParentSampled.shouldSample(context, traceId, spanName,
-              spanKind, spanIsRemote, spanAttributes, spanLinks)
-          : _remoteParentNotSampled.shouldSample(context, traceId, spanName,
-              spanKind, spanIsRemote, spanAttributes, spanLinks);
+          ? _remoteParentSampled.shouldSample(
+              context, traceId, spanName, spanKind, spanAttributes, spanLinks)
+          : _remoteParentNotSampled.shouldSample(
+              context, traceId, spanName, spanKind, spanAttributes, spanLinks);
     }
 
     return (parentSpanContext.traceFlags & api.TraceFlags.sampled) ==
             api.TraceFlags.sampled
-        ? _localParentSampled.shouldSample(context, traceId, spanName, spanKind,
-            spanIsRemote, spanAttributes, spanLinks)
-        : _localParentNotSampled.shouldSample(context, traceId, spanName,
-            spanKind, spanIsRemote, spanAttributes, spanLinks);
+        ? _localParentSampled.shouldSample(
+            context, traceId, spanName, spanKind, spanAttributes, spanLinks)
+        : _localParentNotSampled.shouldSample(
+            context, traceId, spanName, spanKind, spanAttributes, spanLinks);
   }
 }

--- a/lib/src/sdk/trace/sampling/sampler.dart
+++ b/lib/src/sdk/trace/sampling/sampler.dart
@@ -9,7 +9,6 @@ abstract class Sampler {
       api.TraceId traceId,
       String spanName,
       api.SpanKind spanKind,
-      bool spanIsRemote, // ignore: avoid_positional_boolean_parameters
       List<api.Attribute> spanAttributes,
       List<api.SpanLink> spanLinks);
 

--- a/lib/src/sdk/trace/tracer.dart
+++ b/lib/src/sdk/trace/tracer.dart
@@ -48,8 +48,8 @@ class Tracer implements api.Tracer {
       traceState = sdk.TraceState.empty();
     }
 
-    final samplerResult = _sampler.shouldSample(
-        context, traceId, name, kind, false, attributes, links);
+    final samplerResult =
+        _sampler.shouldSample(context, traceId, name, kind, attributes, links);
     final traceFlags = (samplerResult.decision == sdk.Decision.recordAndSample)
         ? api.TraceFlags.sampled
         : api.TraceFlags.none;

--- a/test/unit/sdk/exporters/collector_exporter_test.dart
+++ b/test/unit/sdk/exporters/collector_exporter_test.dart
@@ -41,7 +41,8 @@ void main() {
         sdk.DateTimeTimeProvider(),
         resource,
         instrumentationLibrary,
-        attributes: [api.Attribute.fromString('foo', 'bar')])
+        attributes: [api.Attribute.fromString('foo', 'bar')],
+        kind: api.SpanKind.client)
       ..end();
     final span2 = Span(
         'baz',
@@ -52,7 +53,8 @@ void main() {
         sdk.DateTimeTimeProvider(),
         resource,
         instrumentationLibrary,
-        attributes: [api.Attribute.fromBoolean('bool', true)])
+        attributes: [api.Attribute.fromBoolean('bool', true)],
+        kind: api.SpanKind.internal)
       ..end();
 
     sdk.CollectorExporter(uri, httpClient: mockClient).export([span1, span2]);
@@ -81,7 +83,8 @@ void main() {
                       ],
                       status: pb.Status(
                           code: pb.Status_StatusCode.STATUS_CODE_UNSET,
-                          message: null)),
+                          message: null),
+                      kind: pb.Span_SpanKind.SPAN_KIND_CLIENT),
                   pb.Span(
                       traceId: [1, 2, 3],
                       spanId: [10, 11, 12],
@@ -96,7 +99,8 @@ void main() {
                       ],
                       status: pb.Status(
                           code: pb.Status_StatusCode.STATUS_CODE_UNSET,
-                          message: null))
+                          message: null),
+                      kind: pb.Span_SpanKind.SPAN_KIND_INTERNAL)
                 ],
                 instrumentationLibrary: pb_common.InstrumentationLibrary(
                     name: 'library_name', version: 'library_version'))

--- a/test/unit/sdk/sampling/always_off_sampler_test.dart
+++ b/test/unit/sdk/sampling/always_off_sampler_test.dart
@@ -20,8 +20,8 @@ void main() {
             'always_off_sampler_test', 'sampler_test_version'));
     final testContext = api.Context.current.withSpan(testSpan);
 
-    final result = sdk.AlwaysOffSampler().shouldSample(testContext, traceId,
-        testSpan.name, api.SpanKind.internal, false, [], []);
+    final result = sdk.AlwaysOffSampler().shouldSample(
+        testContext, traceId, testSpan.name, api.SpanKind.internal, [], []);
 
     expect(result.decision, equals(sdk.Decision.drop));
     expect(result.spanAttributes, equals([]));
@@ -45,13 +45,8 @@ void main() {
             'always_off_sampler_test', 'sampler_test_version'),
         attributes: attributesList);
 
-    final result = sdk.AlwaysOffSampler().shouldSample(
-        api.Context.root,
-        traceId,
-        testSpan.name,
-        api.SpanKind.internal,
-        false,
-        attributesList, []);
+    final result = sdk.AlwaysOffSampler().shouldSample(api.Context.root,
+        traceId, testSpan.name, api.SpanKind.internal, attributesList, []);
 
     expect(result.decision, equals(sdk.Decision.drop));
     expect(result.spanAttributes, attributesList);

--- a/test/unit/sdk/sampling/always_on_sampler_test.dart
+++ b/test/unit/sdk/sampling/always_on_sampler_test.dart
@@ -20,8 +20,8 @@ void main() {
             'always_on_sampler_test', 'sampler_test_version'));
     final testContext = api.Context.current.withSpan(testSpan);
 
-    final result = sdk.AlwaysOnSampler().shouldSample(testContext, traceId,
-        testSpan.name, api.SpanKind.internal, false, [], []);
+    final result = sdk.AlwaysOnSampler().shouldSample(
+        testContext, traceId, testSpan.name, api.SpanKind.internal, [], []);
 
     expect(result.decision, equals(sdk.Decision.recordAndSample));
     expect(result.spanAttributes, equals([]));
@@ -41,7 +41,7 @@ void main() {
             'always_on_sampler_test', 'sampler_test_version'));
 
     final result = sdk.AlwaysOnSampler().shouldSample(api.Context.root, traceId,
-        testSpan.name, api.SpanKind.internal, false, [], []);
+        testSpan.name, api.SpanKind.internal, [], []);
 
     expect(result.decision, equals(sdk.Decision.recordAndSample));
     expect(result.spanAttributes, equals([]));

--- a/test/unit/sdk/sampling/parent_based_sampler_test.dart
+++ b/test/unit/sdk/sampling/parent_based_sampler_test.dart
@@ -27,8 +27,8 @@ void main() {
 
     final testContext = api.Context.current.withSpan(testSpan);
 
-    final result = testSampler.shouldSample(testContext, traceId, testSpan.name,
-        api.SpanKind.internal, false, null, []);
+    final result = testSampler.shouldSample(
+        testContext, traceId, testSpan.name, api.SpanKind.internal, null, []);
 
     expect(result.decision, equals(sdk.Decision.recordAndSample));
     expect(result.spanAttributes, equals(null));
@@ -47,7 +47,7 @@ void main() {
             'parent_sampler_test', 'sampler_test_version'));
 
     final result = testSampler.shouldSample(api.Context.root, traceId,
-        testSpan.name, api.SpanKind.internal, false, null, []);
+        testSpan.name, api.SpanKind.internal, null, []);
 
     expect(result.decision, equals(sdk.Decision.recordAndSample));
     expect(result.spanAttributes, equals(null));
@@ -69,8 +69,8 @@ void main() {
             'parent_sampler_test', 'sampler_test_version'));
     final testContext = api.Context.current.withSpan(testSpan);
 
-    final result = testSampler.shouldSample(testContext, traceId, testSpan.name,
-        api.SpanKind.internal, false, null, []);
+    final result = testSampler.shouldSample(
+        testContext, traceId, testSpan.name, api.SpanKind.internal, null, []);
 
     expect(result.decision, equals(sdk.Decision.recordAndSample));
     expect(result.spanAttributes, equals(null));
@@ -92,8 +92,8 @@ void main() {
             'parent_sampler_test', 'sampler_test_version'));
     final testContext = api.Context.current.withSpan(testSpan);
 
-    final result = testSampler.shouldSample(testContext, traceId, testSpan.name,
-        api.SpanKind.internal, false, [], []);
+    final result = testSampler.shouldSample(
+        testContext, traceId, testSpan.name, api.SpanKind.internal, [], []);
 
     expect(result.decision, equals(sdk.Decision.drop));
     expect(result.spanAttributes, equals([]));
@@ -115,8 +115,8 @@ void main() {
             'parent_sampler_test', 'sampler_test_version'));
     final testContext = api.Context.current.withSpan(testSpan);
 
-    final result = testSampler.shouldSample(testContext, traceId, testSpan.name,
-        api.SpanKind.internal, false, [], []);
+    final result = testSampler.shouldSample(
+        testContext, traceId, testSpan.name, api.SpanKind.internal, [], []);
 
     expect(result.decision, equals(sdk.Decision.recordAndSample));
     expect(result.spanAttributes, equals([]));
@@ -138,8 +138,8 @@ void main() {
             'parent_sampler_test', 'sampler_test_version'));
     final testContext = api.Context.current.withSpan(testSpan);
 
-    final result = testSampler.shouldSample(testContext, traceId, testSpan.name,
-        api.SpanKind.internal, false, [], []);
+    final result = testSampler.shouldSample(
+        testContext, traceId, testSpan.name, api.SpanKind.internal, [], []);
 
     expect(result.decision, equals(sdk.Decision.drop));
     expect(result.spanAttributes, equals([]));


### PR DESCRIPTION
### Notes

This PR adds the following:
* CollectorExporter now exports SpanKind information.
* Parameter `spanIsRemote` has been removed from `Sampler`.  It is not present in the OpenTelemetry specification and was unused.

### Reviewers

@Workiva/product-new-relic 