### PR TITLE
O11Y 1771 Update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @Workiva/product-new-relic will be requested for
+# @Workiva/observability will be requested for
 # review when someone opens a pull request.
-* @Workiva/product-new-relic
+* @Workiva/observability


### PR DESCRIPTION
The Workiva Github team "Product New Relic" has been renamed to Observability.
Updating CODEOWNERS file to reflect the change

[_Created by Sourcegraph batch change `Workiva/replace_github_team`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/replace_github_team)