### PR TITLE
O11Y-1748: OpenTelemetry Dart: Implement forceFlush for SpanExporters

### DIFF
--- a/lib/src/sdk/trace/exporters/collector_exporter.dart
+++ b/lib/src/sdk/trace/exporters/collector_exporter.dart
@@ -175,11 +175,12 @@ class CollectorExporter implements api.SpanExporter {
 
   @override
   void forceFlush() {
-    throw UnimplementedError();
+    return;
   }
 
   @override
   void shutdown() {
     _isShutdown = true;
+    client.close();
   }
 }

--- a/lib/src/sdk/trace/exporters/console_exporter.dart
+++ b/lib/src/sdk/trace/exporters/console_exporter.dart
@@ -34,7 +34,7 @@ class ConsoleExporter implements SpanExporter {
 
   @override
   void forceFlush() {
-    throw UnimplementedError();
+    return;
   }
 
   @override

--- a/lib/src/sdk/trace/span_processors/batch_processor.dart
+++ b/lib/src/sdk/trace/span_processors/batch_processor.dart
@@ -35,6 +35,7 @@ class BatchSpanProcessor implements api.SpanProcessor {
     while (_spanBuffer.isNotEmpty) {
       _flushBatch();
     }
+    _exporter.forceFlush();
   }
 
   @override

--- a/lib/src/sdk/trace/span_processors/simple_processor.dart
+++ b/lib/src/sdk/trace/span_processors/simple_processor.dart
@@ -7,7 +7,9 @@ class SimpleSpanProcessor implements api.SpanProcessor {
   SimpleSpanProcessor(this._exporter);
 
   @override
-  void forceFlush() {}
+  void forceFlush() {
+    _exporter.forceFlush();
+  }
 
   @override
   void onEnd(api.Span span) {

--- a/test/unit/sdk/exporters/collector_exporter_test.dart
+++ b/test/unit/sdk/exporters/collector_exporter_test.dart
@@ -128,6 +128,7 @@ void main() {
       ..shutdown()
       ..export([span]);
 
+    verify(mockClient.close()).called(1);
     verifyNever(mockClient.post(uri,
         body: anything, headers: {'Content-Type': 'application/x-protobuf'}));
   });

--- a/test/unit/sdk/span_processors/batch_processor_test.dart
+++ b/test/unit/sdk/span_processors/batch_processor_test.dart
@@ -36,11 +36,13 @@ void main() {
 
     verify(mockExporter.export([mockSpan1, mockSpan2])).called(1);
     verify(mockExporter.export([mockSpan3])).called(1);
+    verify(mockExporter.forceFlush()).called(1);
   });
 
   test('shutdown shuts exporter down', () {
     processor.shutdown();
 
     verify(mockExporter.shutdown()).called(1);
+    verify(mockExporter.forceFlush()).called(1);
   });
 }

--- a/test/unit/sdk/span_processors/simple_processor_test.dart
+++ b/test/unit/sdk/span_processors/simple_processor_test.dart
@@ -24,12 +24,19 @@ void main() {
     verify(exporter.export([span])).called(1);
   });
 
-  test('does not export if shutdown', () {
+  test('flushes exporter on forced flush', () {
+    processor.forceFlush();
+
+    verify(exporter.forceFlush()).called(1);
+  });
+
+  test('does not export if shut down', () {
     processor
       ..shutdown()
       ..onEnd(span);
 
     verify(exporter.shutdown()).called(1);
+    verify(exporter.forceFlush()).called(1);
     verifyNever(exporter.export([span]));
   });
 }


### PR DESCRIPTION
### Notes

This PR adds `forceFlush` implementation for SpanExporters and utilizes this in SpanProcessors.

Per the [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md):
* The built-in SpanProcessors must call their exporter's Export with all spans for which this was not already done and then invoke ForceFlush on it.
* SpanExporters should export any Spans which they retain but have not yet exported.

### Reviewers
@Workiva/observability 

