### PR TITLE
O11Y-1489: Update span processors to match otel spec

### DIFF
--- a/lib/src/api/span_processors/span_processor.dart
+++ b/lib/src/api/span_processors/span_processor.dart
@@ -1,7 +1,7 @@
 import '../../../api.dart' as api;
 
 abstract class SpanProcessor {
-  void onStart();
+  void onStart(api.Span span, api.Context parentContext);
 
   void onEnd(api.Span span);
 

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -33,6 +33,7 @@ class Span implements api.Span {
       {api.SpanKind kind,
       List<api.Attribute> attributes,
       List<api.SpanLink> links,
+      api.Context parentContext,
       sdk.SpanLimits spanlimits,
       Int64 startTime})
       : _links = links ?? [],
@@ -44,7 +45,7 @@ class Span implements api.Span {
     }
 
     for (var i = 0; i < _processors.length; i++) {
-      _processors[i].onStart();
+      _processors[i].onStart(this, parentContext);
     }
   }
 

--- a/lib/src/sdk/trace/span_processors/batch_processor.dart
+++ b/lib/src/sdk/trace/span_processors/batch_processor.dart
@@ -15,15 +15,15 @@ class BatchSpanProcessor implements api.SpanProcessor {
 
   int _maxExportBatchSize = 512;
   final int _maxQueueSize = 2048;
-  int _scheduledDelay = 5000;
+  int _scheduledDelayMillis = 5000;
 
   BatchSpanProcessor(this._exporter,
-      {int maxExportBatchSize, int scheduledDelay}) {
+      {int maxExportBatchSize, int scheduledDelayMillis}) {
     if (maxExportBatchSize != null) {
       _maxExportBatchSize = maxExportBatchSize;
     }
-    if (scheduledDelay != null) {
-      _scheduledDelay = scheduledDelay;
+    if (scheduledDelayMillis != null) {
+      _scheduledDelayMillis = scheduledDelayMillis;
     }
   }
 
@@ -47,7 +47,7 @@ class BatchSpanProcessor implements api.SpanProcessor {
   }
 
   @override
-  void onStart() {}
+  void onStart(api.Span span, api.Context parentContext) {}
 
   @override
   void shutdown() {
@@ -75,7 +75,7 @@ class BatchSpanProcessor implements api.SpanProcessor {
       return;
     }
 
-    _timer = Timer(Duration(milliseconds: _scheduledDelay), () {
+    _timer = Timer(Duration(milliseconds: _scheduledDelayMillis), () {
       _flushBatch();
       if (_spanBuffer.isNotEmpty) {
         _clearTimer();

--- a/lib/src/sdk/trace/span_processors/simple_processor.dart
+++ b/lib/src/sdk/trace/span_processors/simple_processor.dart
@@ -21,7 +21,7 @@ class SimpleSpanProcessor implements api.SpanProcessor {
   }
 
   @override
-  void onStart() {}
+  void onStart(api.Span span, api.Context parentContext) {}
 
   @override
   void shutdown() {

--- a/lib/src/sdk/trace/tracer.dart
+++ b/lib/src/sdk/trace/tracer.dart
@@ -61,6 +61,7 @@ class Tracer implements api.Tracer {
         kind: kind,
         attributes: attributes,
         links: links,
+        parentContext: context,
         spanlimits: _spanLimits,
         startTime: startTime);
   }

--- a/test/integration/sdk/span_test.dart
+++ b/test/integration/sdk/span_test.dart
@@ -27,8 +27,8 @@ void main() {
     expect(span.parentSpanId, same(parentSpanId));
     expect(span.name, 'foo');
 
-    verify(mockProcessor1.onStart()).called(1);
-    verify(mockProcessor2.onStart()).called(1);
+    verify(mockProcessor1.onStart(span, null)).called(1);
+    verify(mockProcessor2.onStart(span, null)).called(1);
     verifyNever(mockProcessor1.onEnd(span));
     verifyNever(mockProcessor2.onEnd(span));
 

--- a/test/unit/sdk/span_processors/batch_processor_test.dart
+++ b/test/unit/sdk/span_processors/batch_processor_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     mockExporter = MockSpanExporter();
     processor = BatchSpanProcessor(mockExporter,
-        maxExportBatchSize: 2, scheduledDelay: 100);
+        maxExportBatchSize: 2, scheduledDelayMillis: 100);
   });
 
   tearDown(() {


### PR DESCRIPTION
Update the span processors api so it matches the Opentelemetry specification, which is needed for the user timing processor in wo11y-dart.