### PR TITLE
O11Y-2148: Enable 3rd parties to view CI results

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,10 +1,16 @@
 name: opentelemetry-dart
 contact: "Slack: #support-observability"
-description: Placeholder test to be updated prior to 1.0 release.
+description: Verify that the github actions run passed, this is needed to make pipelines pass without manual intervention
+env:
+# encrypted github token used for requests to api.github.com
+ - secure: +ZZnIr6KoTG7amJ6UoCsSz3MtdQfG/B1oiJqjLQQ/rKd8TScT3XP2Zp7yHAp9VOH+8iBOmRG1tRsXdmm/cYqK7YcjZA=
+image: drydock.workiva.net/workiva/skynet-images:3693290 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
 run:
-  when-branch-name-is:
-    - .+
+  on-pull-request: true
+  on-promotion: true
+  when-modified-file-name-is: 
+    - skynet.yaml
+scripts:
+  - python3 /actions/verify_github_actions.py
 size: small
 timeout: 300
-scripts:
-  - 'true'


### PR DESCRIPTION
## Motivation
Currently, 3rd parties cannot see the results of the CI process. This limits their ability to contribute to this codebase. Since our CI is based on Github actions, we would like to provide visibility into them. Additionally, We would like to not have to manually check that the github workflow passed and override the pipeline so we need a way to automatically check that the workflow passed and tell the pipeline that all is good.

fixes #64 

## Changes
-Modified the skynet.yaml so that we check that the github workflow runs and passes or fails the skynet run depending on the results.

#### Release Notes
Modifies the skynet.yaml so that we checks the github workflow run and passes or fails the skynet run depending on the results.


### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A maintainer has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_

