### PR TITLE
TESTING: Release opentelemetry-dart 0.15.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: opentelemetry
-version: 1.0.0
+version: 0.15.0
 description: A framework for collecting traces from applications.
 homepage: https://github.com/Workiva/opentelemetry-dart
 environment:


### PR DESCRIPTION
This is a test pull request triggered from w-rmconsole and is not intended for merge.

Pull Requests included in release:
* Major changes:
	* [O11Y-2238 moved to api](https://github.com/Workiva/opentelemetry-dart/pull/81)


Diff Between Last Tag and Proposed Release: https://github.com/Workiva/opentelemetry-dart/compare/0.14.3...Workiva:release_opentelemetry-dart_0.15.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/opentelemetry-dart/compare/0.14.3...0.15.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6283444899020800/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6283444899020800/?repo_name=Workiva%2Fopentelemetry-dart&pull_number=85)