### PR TITLE
O11Y-2352 : added missing dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
+  collection: ^1.0.0
   fixnum: '>=0.10.0 <2.0.0'
   http: ^0.12.0
   logging: '>=0.11.4 <2.0.0'


### PR DESCRIPTION
## Which problem is this PR solving?

When publishing to the pub server, an error prevents the library from being uploaded due to a dependency being referenced in code yet not listed in the pubspec.yaml

## How Has This Been Tested?

Made this change and then published 0.15.0 to the public pub server.

FYI: @Workiva/observability 