### PR TITLE
O11Y-2256 : Resource can be passed into MeterProvider

### DIFF
--- a/lib/src/api/metrics/noop/noop_meter_provider.dart
+++ b/lib/src/api/metrics/noop/noop_meter_provider.dart
@@ -1,5 +1,4 @@
 import 'package:opentelemetry/api.dart';
-import 'package:opentelemetry/src/api/metrics/noop/noop_meter.dart';
 import 'package:opentelemetry/src/experimental_api.dart';
 
 /// A noop registry for creating named [Meter]s.

--- a/lib/src/experimental_api.dart
+++ b/lib/src/experimental_api.dart
@@ -1,3 +1,8 @@
+@experimental
+library experimental_api;
+
+import 'package:meta/meta.dart';
+
 export 'api/metrics/counter.dart' show Counter;
 export 'api/metrics/meter_provider.dart' show MeterProvider;
 export 'api/metrics/meter.dart' show Meter;

--- a/lib/src/experimental_api.dart
+++ b/lib/src/experimental_api.dart
@@ -1,3 +1,4 @@
 export 'api/metrics/counter.dart' show Counter;
 export 'api/metrics/meter_provider.dart' show MeterProvider;
 export 'api/metrics/meter.dart' show Meter;
+export 'api/metrics/noop/noop_meter.dart' show NoopMeter;

--- a/lib/src/experimental_sdk.dart
+++ b/lib/src/experimental_sdk.dart
@@ -1,3 +1,7 @@
 export 'sdk/metrics/counter.dart' show Counter;
 export 'sdk/metrics/meter_provider.dart' show MeterProvider;
 export 'sdk/metrics/meter.dart' show Meter;
+export 'sdk/metrics/state/meter_shared_state.dart' show MeterSharedState;
+export 'sdk/metrics/state/meter_provider_shared_state.dart'
+    show MeterProviderSharedState;
+export 'sdk/resource/resource.dart' show Resource;

--- a/lib/src/experimental_sdk.dart
+++ b/lib/src/experimental_sdk.dart
@@ -6,7 +6,4 @@ import 'package:meta/meta.dart';
 export 'sdk/metrics/counter.dart' show Counter;
 export 'sdk/metrics/meter_provider.dart' show MeterProvider;
 export 'sdk/metrics/meter.dart' show Meter;
-export 'sdk/metrics/state/meter_shared_state.dart' show MeterSharedState;
-export 'sdk/metrics/state/meter_provider_shared_state.dart'
-    show MeterProviderSharedState;
 export 'sdk/resource/resource.dart' show Resource;

--- a/lib/src/experimental_sdk.dart
+++ b/lib/src/experimental_sdk.dart
@@ -1,3 +1,8 @@
+@experimental
+library experimental_sdk;
+
+import 'package:meta/meta.dart';
+
 export 'sdk/metrics/counter.dart' show Counter;
 export 'sdk/metrics/meter_provider.dart' show MeterProvider;
 export 'sdk/metrics/meter.dart' show Meter;

--- a/lib/src/sdk/common/instrumentation_scope.dart
+++ b/lib/src/sdk/common/instrumentation_scope.dart
@@ -1,9 +1,13 @@
+import 'package:opentelemetry/api.dart' as api;
+
 class InstrumentationScope {
   final String _name;
   final String _version;
   final String _schemaUrl;
+  final List<api.Attribute> _attributes;
 
-  InstrumentationScope(this._name, this._version, this._schemaUrl);
+  InstrumentationScope(
+      this._name, this._version, this._schemaUrl, this._attributes);
 
   String get name {
     return _name;
@@ -15,5 +19,9 @@ class InstrumentationScope {
 
   String get schemaUrl {
     return _schemaUrl;
+  }
+
+  List<api.Attribute> get attributes {
+    return _attributes;
   }
 }

--- a/lib/src/sdk/common/instrumentation_scope.dart
+++ b/lib/src/sdk/common/instrumentation_scope.dart
@@ -1,0 +1,19 @@
+class InstrumentationScope {
+  final String _name;
+  final String _version;
+  final String _schemaUrl;
+
+  InstrumentationScope(this._name, this._version, this._schemaUrl);
+
+  String get name {
+    return _name;
+  }
+
+  String get version {
+    return _version;
+  }
+
+  String get schemaUrl {
+    return _schemaUrl;
+  }
+}

--- a/lib/src/sdk/metrics/meter.dart
+++ b/lib/src/sdk/metrics/meter.dart
@@ -2,6 +2,11 @@ import 'package:opentelemetry/src/experimental_sdk.dart' as sdk;
 import 'package:opentelemetry/src/experimental_api.dart' as api;
 
 class Meter implements api.Meter {
+  // ignore: unused_field
+  final sdk.MeterSharedState _state;
+
+  Meter(this._state);
+
   @override
   api.Counter<T> createCounter<T extends num>(String name,
       {String description, String unit}) {

--- a/lib/src/sdk/metrics/meter.dart
+++ b/lib/src/sdk/metrics/meter.dart
@@ -1,9 +1,11 @@
 import 'package:opentelemetry/src/experimental_sdk.dart' as sdk;
 import 'package:opentelemetry/src/experimental_api.dart' as api;
 
+import 'state/meter_shared_state.dart';
+
 class Meter implements api.Meter {
   // ignore: unused_field
-  final sdk.MeterSharedState _state;
+  final MeterSharedState _state;
 
   Meter(this._state);
 

--- a/lib/src/sdk/metrics/meter_provider.dart
+++ b/lib/src/sdk/metrics/meter_provider.dart
@@ -2,16 +2,23 @@ import 'package:opentelemetry/api.dart' as api;
 import 'package:opentelemetry/src/experimental_api.dart' as api;
 import 'package:opentelemetry/src/experimental_sdk.dart' as sdk;
 import 'package:logging/logging.dart';
-import 'package:opentelemetry/src/api/metrics/meter_key.dart';
+import 'package:opentelemetry/src/sdk/common/instrumentation_scope.dart';
+import 'package:opentelemetry/src/sdk/metrics/state/meter_provider_shared_state.dart';
 
 const invalidMeterNameMessage = 'Invalid Meter Name';
 
 class MeterProvider implements api.MeterProvider {
-  final _meters = <MeterKey, api.Meter>{};
   final _logger = Logger('opentelemetry.sdk.metrics.meterprovider');
+  final _shutdown = false;
+  final MeterProviderSharedState _sharedState;
+
+  sdk.Resource get resource => _sharedState.resource;
+
+  MeterProvider({sdk.Resource resource})
+      : _sharedState = MeterProviderSharedState(resource);
 
   @override
-  sdk.Meter get(String name,
+  api.Meter get(String name,
       {String version = '',
       String schemaUrl = '',
       List<api.Attribute> attributes = const []}) {
@@ -19,11 +26,15 @@ class MeterProvider implements api.MeterProvider {
       name = '';
       _logger.warning(invalidMeterNameMessage, '', StackTrace.current);
     }
-    version ??= '';
-    schemaUrl ??= '';
-    attributes ??= const [];
-    final key = MeterKey(name, version, schemaUrl, attributes);
 
-    return _meters.putIfAbsent(key, () => sdk.Meter());
+    if (_shutdown) {
+      _logger.warning('A shutdown MeterProvider cannot provide a Meter', '',
+          StackTrace.current);
+      return api.NoopMeter();
+    }
+
+    return _sharedState
+        .getMeterSharedState(InstrumentationScope(name, version, schemaUrl))
+        .meter;
   }
 }

--- a/lib/src/sdk/metrics/meter_provider.dart
+++ b/lib/src/sdk/metrics/meter_provider.dart
@@ -34,7 +34,7 @@ class MeterProvider implements api.MeterProvider {
     }
 
     return _sharedState
-        .getMeterSharedState(InstrumentationScope(name, version, schemaUrl))
+        .getMeterSharedState(InstrumentationScope(name, version, schemaUrl, attributes))
         .meter;
   }
 }

--- a/lib/src/sdk/metrics/state/meter_provider_shared_state.dart
+++ b/lib/src/sdk/metrics/state/meter_provider_shared_state.dart
@@ -4,8 +4,13 @@ import 'package:opentelemetry/src/sdk/metrics/state/meter_shared_state.dart';
 import 'package:quiver/core.dart';
 
 int instrumentationScopeId(InstrumentationScope instrumentationScope) {
-  return hash4(instrumentationScope.name, instrumentationScope.version,
-      instrumentationScope.schemaUrl, instrumentationScope.attributes);
+  return hash4(
+      instrumentationScope.name,
+      instrumentationScope.version,
+      instrumentationScope.schemaUrl,
+      instrumentationScope.attributes.isEmpty
+          ? const []
+          : instrumentationScope.attributes);
 }
 
 class MeterProviderSharedState {

--- a/lib/src/sdk/metrics/state/meter_provider_shared_state.dart
+++ b/lib/src/sdk/metrics/state/meter_provider_shared_state.dart
@@ -4,28 +4,23 @@ import 'package:opentelemetry/src/sdk/metrics/state/meter_shared_state.dart';
 import 'package:quiver/core.dart';
 
 int instrumentationScopeId(InstrumentationScope instrumentationScope) {
-  return hash4(
-      instrumentationScope.name,
-      instrumentationScope.version,
-      instrumentationScope.schemaUrl,
-      instrumentationScope.attributes.isEmpty
-          ? const []
-          : instrumentationScope.attributes);
+  return hash3(instrumentationScope.name, instrumentationScope.version,
+      instrumentationScope.schemaUrl);
 }
 
 class MeterProviderSharedState {
   Resource resource;
-  Map<int, MeterSharedState> meterSharedStates = {};
+  final Map<int, MeterSharedState> _meterSharedStates = {};
 
   MeterProviderSharedState(this.resource);
 
   MeterSharedState getMeterSharedState(
       InstrumentationScope instrumentationScope) {
     final id = instrumentationScopeId(instrumentationScope);
-    var meterSharedState = meterSharedStates[id];
+    var meterSharedState = _meterSharedStates[id];
     if (meterSharedState == null) {
       meterSharedState = MeterSharedState(this, instrumentationScope);
-      meterSharedStates[id] = meterSharedState;
+      _meterSharedStates[id] = meterSharedState;
     }
     return meterSharedState;
   }

--- a/lib/src/sdk/metrics/state/meter_provider_shared_state.dart
+++ b/lib/src/sdk/metrics/state/meter_provider_shared_state.dart
@@ -1,14 +1,16 @@
 import 'package:opentelemetry/sdk.dart';
 import 'package:opentelemetry/src/sdk/common/instrumentation_scope.dart';
 import 'package:opentelemetry/src/sdk/metrics/state/meter_shared_state.dart';
+import 'package:quiver/core.dart';
 
-String instrumentationScopeId(InstrumentationScope instrumentationScope) {
-  return "${instrumentationScope.name}:${instrumentationScope.version ?? ''}:${instrumentationScope.schemaUrl ?? ''}";
+int instrumentationScopeId(InstrumentationScope instrumentationScope) {
+  return hash4(instrumentationScope.name, instrumentationScope.version,
+      instrumentationScope.schemaUrl, instrumentationScope.attributes);
 }
 
 class MeterProviderSharedState {
   Resource resource;
-  Map<String, MeterSharedState> meterSharedStates = {};
+  Map<int, MeterSharedState> meterSharedStates = {};
 
   MeterProviderSharedState(this.resource);
 

--- a/lib/src/sdk/metrics/state/meter_provider_shared_state.dart
+++ b/lib/src/sdk/metrics/state/meter_provider_shared_state.dart
@@ -1,0 +1,25 @@
+import 'package:opentelemetry/sdk.dart';
+import 'package:opentelemetry/src/sdk/common/instrumentation_scope.dart';
+import 'package:opentelemetry/src/sdk/metrics/state/meter_shared_state.dart';
+
+String instrumentationScopeId(InstrumentationScope instrumentationScope) {
+  return "${instrumentationScope.name}:${instrumentationScope.version ?? ''}:${instrumentationScope.schemaUrl ?? ''}";
+}
+
+class MeterProviderSharedState {
+  Resource resource;
+  Map<String, MeterSharedState> meterSharedStates = {};
+
+  MeterProviderSharedState(this.resource);
+
+  MeterSharedState getMeterSharedState(
+      InstrumentationScope instrumentationScope) {
+    final id = instrumentationScopeId(instrumentationScope);
+    var meterSharedState = meterSharedStates[id];
+    if (meterSharedState == null) {
+      meterSharedState = MeterSharedState(this, instrumentationScope);
+      meterSharedStates[id] = meterSharedState;
+    }
+    return meterSharedState;
+  }
+}

--- a/lib/src/sdk/metrics/state/meter_shared_state.dart
+++ b/lib/src/sdk/metrics/state/meter_shared_state.dart
@@ -2,9 +2,11 @@ import 'package:opentelemetry/src/sdk/common/instrumentation_scope.dart';
 
 import 'package:opentelemetry/src/experimental_sdk.dart' as sdk;
 
+import 'meter_provider_shared_state.dart';
+
 class MeterSharedState {
   // ignore: unused_field
-  final sdk.MeterProviderSharedState _meterProviderSharedState;
+  final MeterProviderSharedState _meterProviderSharedState;
   // ignore: unused_field
   final InstrumentationScope _instrumentationScope;
   sdk.Meter meter;

--- a/lib/src/sdk/metrics/state/meter_shared_state.dart
+++ b/lib/src/sdk/metrics/state/meter_shared_state.dart
@@ -1,0 +1,15 @@
+import 'package:opentelemetry/src/sdk/common/instrumentation_scope.dart';
+
+import 'package:opentelemetry/src/experimental_sdk.dart' as sdk;
+
+class MeterSharedState {
+  // ignore: unused_field
+  final sdk.MeterProviderSharedState _meterProviderSharedState;
+  // ignore: unused_field
+  final InstrumentationScope _instrumentationScope;
+  sdk.Meter meter;
+
+  MeterSharedState(this._meterProviderSharedState, this._instrumentationScope) {
+    meter = sdk.Meter(this);
+  }
+}

--- a/test/unit/sdk/metrics/meter_provider_test.dart
+++ b/test/unit/sdk/metrics/meter_provider_test.dart
@@ -157,6 +157,12 @@ void main() {
       expect(identical(meterA, meterB), false);
     });
 
+    test('resource can be set', () {
+      final resource = sdk.Resource([api.Attribute.fromString('foo', 'bar')]);
+      final provider = sdk.MeterProvider(resource: resource);
+      expect(identical(resource, provider.resource), true);
+    });
+
     // todo: implement test that verifies that changes to attributes apply to
     // previously created meters
     // https://github.com/Workiva/opentelemetry-dart/issues/74

--- a/test/unit/sdk/metrics/meter_provider_test.dart
+++ b/test/unit/sdk/metrics/meter_provider_test.dart
@@ -136,7 +136,7 @@ void main() {
 
     test(
         'getting by same name, same version, same schema_url and different '
-        'attributes will return different meter instances', () {
+        'attributes will return the same meter instance', () {
       const meterName = 'meterA';
       const version = 'v2';
       const url = 'http:schemas.com';
@@ -154,7 +154,7 @@ void main() {
       final meterB = meterProvider.get(meterName,
           version: version, schemaUrl: url, attributes: attributesB);
 
-      expect(identical(meterA, meterB), false);
+      expect(identical(meterA, meterB), true);
     });
 
     test('resource can be set', () {

--- a/test/unit/sdk/metrics/state/instrumentation_scope_id_test.dart
+++ b/test/unit/sdk/metrics/state/instrumentation_scope_id_test.dart
@@ -1,0 +1,42 @@
+@TestOn('vm')
+
+import 'package:logging/logging.dart';
+import 'package:opentelemetry/api.dart';
+import 'package:opentelemetry/src/sdk/common/instrumentation_scope.dart';
+import 'package:opentelemetry/src/sdk/metrics/state/meter_provider_shared_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('instrumentationScopeId:', () {
+    setUp(() {
+      Logger.root.level = Level.ALL; // defaults to Level.INFO
+      Logger.root.onRecord.listen((record) {
+        printOnFailure(
+            '${record.level.name}: ${record.time}: ${record.message}');
+      });
+    });
+
+    test('instrumentationScopeId with same parameters returns same id', () {
+      //int instrumentationScopeId(InstrumentationScope instrumentationScope) {
+      const nameOne = 'testName';
+      const versionOne = '';
+      const schemaUrlOne = '';
+      const attributesOne = <Attribute>[];
+
+      const nameTwo = 'testName';
+      const versionTwo = '';
+      const schemaUrlTwo = '';
+      const attributesTwo = <Attribute>[];
+
+      final scopeOne = InstrumentationScope(
+          nameOne, versionOne, schemaUrlOne, attributesOne);
+      final idOne = instrumentationScopeId(scopeOne);
+
+      final scopeTwo = InstrumentationScope(
+          nameTwo, versionTwo, schemaUrlTwo, attributesTwo);
+      final idTwo = instrumentationScopeId(scopeTwo);
+
+      expect(idOne, equals(idTwo));
+    });
+  });
+}


### PR DESCRIPTION
## Which problem is this PR solving?

It should be possible to associate a Resource with a MeterProvider so that all derivative instruments share the resource.

These changes allow a resource to be passed into the MeterProvider constructor and further build on the effort to bring metrics support to this library


## How Has This Been Tested?

- Please see unit-test


## Checklist:

- [x] Unit tests have been added
- [ ] Documentation has been updated

@Workiva/observability 