### PR TITLE
Update http to ^0.13.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   collection: ^1.0.0
   fixnum: '>=0.10.0 <2.0.0'
-  http: ^0.12.0
+  http: ^0.13.0
   logging: '>=0.11.4 <2.0.0'
   protobuf: '>=1.1.0 <3.0.0'
   quiver: '>=2.1.5 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   collection: ^1.0.0
   fixnum: '>=0.10.0 <2.0.0'
-  http: ^0.13.0
+  http: '>=0.12.0 <0.14.0'
   logging: '>=0.11.4 <2.0.0'
   protobuf: '>=1.1.0 <3.0.0'
   quiver: '>=2.1.5 <4.0.0'


### PR DESCRIPTION
## Which problem is this PR solving?

Unblocking the upgrade of the http dependency to the newest version. This will allow both the newer http version and the current version. In this way, this release will still be consumable inside Workiva while we upgrade other places to http 0.13.0. A subsequent PR can then raise the dependency to require ^0.13.0 and migrate it to null safety.

## Short description of the change

Changes the http dependency from `^0.12.0` to `>=0.12.0 <0.14.0`

## How Has This Been Tested?

Automated tests in Github Actions
