### PR TITLE
O11Y-2363: Widen http on 0.14.x line

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 
 dependencies:
   fixnum: '>=0.10.0 <2.0.0'
-  http: ^0.12.0
+  http: '>=0.12.0 <0.14.0'
   logging: '>=0.11.4 <2.0.0'
   protobuf: '>=1.1.0 <3.0.0'
 


### PR DESCRIPTION
# [O11Y-2363](https://jira.atl.workiva.net/browse/O11Y-2363)
![Issue Status](https://h.inf-dev.workiva.org/s/wk-backend/jira/status/O11Y-2363)

Widen the http dependency range on the 0.14.x release line as well so that consumers who are on 0.14.x can resolve to http 0.13.x

Note this merge is targeting the 0.14.x branch, where a 0.14.4 release will be created from.