### PR TITLE
Pin mockito 5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,4 +18,7 @@ dev_dependencies:
   remove_from_coverage: ^2.0.0
   test: ^1.16.5
   workiva_analysis_options: ^1.2.2
+dependency_validator:
+  ignore:
+    - mockito
   


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

We've discovered that mockito 5.3.0 is not compatible with analyzer 2x.
So as we work to get repos upgraded to analyzer 2, mockito will start to fail
to compile. We can avoid this by setting an upper bound to avoid the known bad version.
mockito 5.3.1 and higher are ok, but require analyzer 4+

This batch will change the mockito dependency from ^5.0.0 to `'>=5.0.0 <5.3.0'`
and may add a dependency_validator ignore for the pinned version of mockito
if neccessary.

A passing CI is sufficient QA (means mockito compiles and tests run).

For more info, reach out to Rob Becker in `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/pin_mockito_5`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/pin_mockito_5)