### PR TITLE
Update dart dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   collection: ^1.0.0
   fixnum: '>=0.10.0 <2.0.0'
   http: '>=0.12.0 <0.14.0'
-  logging: '>=0.11.4 <2.0.0'
+  logging: ^1.0.0
   protobuf: '>=1.1.0 <3.0.0'
   quiver: '>=2.1.5 <4.0.0'
 


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

```
  # Raise minimums for package versions that we already resolve to
  pubspec_codemod raise-min built_redux 8.0.0 --recursive
  pubspec_codemod raise-min logging 1.0.0 --recursive
  pubspec_codemod raise-min glob 2.0.0 --recursive
  pubspec_codemod raise-min yaml 3.0.0 --recursive
  pubspec_codemod raise-min archive 3.0.0 --recursive
  pubspec_codemod raise-min xml 5.0.0 --recursive

  # allow next versions (io 1 and memoize 3)
  pubspec_codemod raise-max io 2.0.0 --recursive
  pubspec_codemod raise-max memoize 4.0.0 --recursive
   
  # Allow the nullsafe version of intl and color
  pubspec_codemod raise-min intl 0.17.0 --recursive
  pubspec_codemod raise-max intl 0.19.0 --recursive
  pubspec_codemod raise-max color 4.0.0 --recursive
```

A passing CI is sufficient QA (means dependencies resolve and tests run and pass).

For more info, reach out to Rob Becker in `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/update_deps_april_23`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/update_deps_april_23)