### PR TITLE
O11Y-2859: Disable code coverage comments on pull requests

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -15,14 +15,14 @@ permissions:
   
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: workiva-runner-dev-small
     strategy:
       matrix:
         # Don't run on newer SDKs until we're able to get on analyzer 1.x,
         # since our current analyzer version range results in build failures
         # when analysis hits the `<<<` operator.
         # sdk: [ 2.13.4, stable, dev ]
-        sdk: [ 2.13.4 ]
+        sdk: [ 2.18.7 ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -18,7 +18,7 @@ permissions:
   
 jobs:
   test:
-    runs-on: [self-hosted, workiva-runner-dev-small]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,6 +45,7 @@ jobs:
       - name: Ignore Files For Coverage
         run: pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r 'lib\/src\/sdk\/proto\/opentelemetry\/proto\/.+'
       - uses: romeovs/lcov-reporter-action@v0.3.1
+        continue-on-error: true
         with:
           lcov-file: ./coverage/lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - '*'
+concurrency:
+  group: opentelemetry-coverage-${{ github.ref }}-1
+  cancel-in-progress: true
 permissions:
   contents: read
   issues: write
@@ -15,21 +18,14 @@ permissions:
   
 jobs:
   test:
-    runs-on: workiva-runner-dev-small
-    strategy:
-      matrix:
-        # Don't run on newer SDKs until we're able to get on analyzer 1.x,
-        # since our current analyzer version range results in build failures
-        # when analysis hits the `<<<` operator.
-        # sdk: [ 2.13.4, stable, dev ]
-        sdk: [ 2.18.7 ]
+    runs-on: [self-hosted, workiva-runner-dev-small]
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: ${{ matrix.sdk }}
+          sdk: 2.18.7
       - name: Install protobuf-compiler
         run: sudo apt install -y protobuf-compiler
       - name: Install Dart dependencies

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Activate RemoveFromCoverage Package
         run: dart pub global activate remove_from_coverage
       - name: Ignore Files For Coverage
-        run: pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r 'lib\/src\/sdk\/proto\/opentelemetry\/proto\/.+'
+        run: dart pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r 'lib\/src\/sdk\/proto\/opentelemetry\/proto\/.+'
       - uses: romeovs/lcov-reporter-action@v0.3.1
         continue-on-error: true
         with:

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -44,8 +44,3 @@ jobs:
         run: dart pub global activate remove_from_coverage
       - name: Ignore Files For Coverage
         run: dart pub global run remove_from_coverage:remove_from_coverage -f coverage/lcov.info -r 'lib\/src\/sdk\/proto\/opentelemetry\/proto\/.+'
-      - uses: romeovs/lcov-reporter-action@v0.3.1
-        continue-on-error: true
-        with:
-          lcov-file: ./coverage/lcov.info
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Which problem is this PR solving?

The CI for this repo depends on the Github token when posting code coverage info to the pull request.  When 3rd parties propose changes, the CI fails because the Github token is not available to those 3rd parties.

Fixes # (issue)

## Short description of the change
- Disabled codecoverage commenting on the pr (we can revisit later, once we have identified a permanent solution)

## How Has This Been Tested?

The CI on this pr can confirm these changes will not disrupt the CI workflow.
