### PR TITLE
Add dependency for meta to pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   fixnum: '>=0.10.0 <2.0.0'
   http: '>=0.12.0 <0.14.0'
   logging: ^1.0.0
+  meta: ^1.9.1
   protobuf: '>=1.1.0 <3.0.0'
   quiver: '>=2.1.5 <4.0.0'
 
@@ -21,4 +22,3 @@ dev_dependencies:
 dependency_validator:
   ignore:
     - mockito
-  

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   fixnum: '>=0.10.0 <2.0.0'
   http: '>=0.12.0 <0.14.0'
   logging: ^1.0.0
-  meta: ^1.9.1
+  meta: '>=1.6.0 <2.0.0'
   protobuf: '>=1.1.0 <3.0.0'
   quiver: '>=2.1.5 <4.0.0'
 


### PR DESCRIPTION
## Which problem is this PR solving?

Attempting to package this library with `dart pub publish` results in the following message:
```
Package validation found the following errors:
* line 4, column 1 of lib/src/experimental_api.dart: This package does not have meta in the `dependencies` section of `pubspec.yaml`.
    ╷
  4 │ import 'package:meta/meta.dart';
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
* line 4, column 1 of lib/src/experimental_sdk.dart: This package does not have meta in the `dependencies` section of `pubspec.yaml`.
    ╷
  4 │ import 'package:meta/meta.dart';
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
```
...which prevent this library from releasing.

Fixes # (issue)

`meta` has been added to `pubspec.yaml` at version 1.9.1 (latest).


## How Has This Been Tested?

1. Verified the presence of the described issue without changes to `pubspec.yaml`.
2. Verified the absence of the described issue following changes to `pubspec.yaml`.


## Checklist:

- [ ] Unit tests have been added
- [ ] Documentation has been updated