### PR TITLE
Allow custom timestamps to be used on Span.end()

### DIFF
--- a/lib/src/api/trace/nonrecording_span.dart
+++ b/lib/src/api/trace/nonrecording_span.dart
@@ -25,7 +25,7 @@ class NonRecordingSpan implements api.Span {
   void setAttributes(List<api.Attribute> attributes) {}
 
   @override
-  void end() {}
+  void end({Int64? endTime}) {}
 
   @override
   void setName(String _name) {}

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -64,7 +64,7 @@ abstract class Span {
       {Int64? timestamp, List<api.Attribute> attributes});
 
   /// Marks the end of this span's execution.
-  void end();
+  void end({Int64 endTime});
 
   /// Record metadata about an exception occurring during this span.
   void recordException(dynamic exception, {StackTrace stackTrace});

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -70,12 +70,12 @@ class Span implements sdk.ReadWriteSpan {
   api.SpanId get parentSpanId => _parentSpanId;
 
   @override
-  void end() {
+  void end({Int64? endTime}) {
     if (!isRecording) {
       return;
     }
 
-    _endTime = _timeProvider.now;
+    _endTime ??= endTime ?? _timeProvider.now;
 
     for (var i = 0; i < _processors.length; i++) {
       _processors[i].onEnd(this);


### PR DESCRIPTION
## Which problem is this PR solving?

Currently it's possible to start spans with a custom `startTime` but it isn't possible to set a custom `endTime` when ending them. This is useful for dispatching spans that happened on a different time window than the moment in which `start()/end()` were called.

## Short description of the change

This PR adds a new optional `endTime` parameter to the `Span.end()` method which allows a custom `endTime` to be set on the Span rather than always using the `timestamp.now`.

## How Has This Been Tested?

Added a new integration test in which we create a Span with a custom `startTime` and then end it with a custom `endTime` and validate the actual reported timestamps.

## Checklist:

- [ ] Unit tests have been added
- [ ] Documentation has been updated