### PR TITLE
Avoid meta 1.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   fixnum: '>=0.10.0 <2.0.0'
   http: '>=0.12.0 <0.14.0'
   logging: ^1.0.0
-  meta: '>=1.6.0 <2.0.0'
+  meta: '>=1.6.0  <1.10.0'
   protobuf: '>=1.1.0 <3.0.0'
   quiver: '>=2.1.5 <4.0.0'
 
@@ -22,4 +22,5 @@ dev_dependencies:
 
 dependency_validator:
   ignore:
+    - meta
     - mockito


### PR DESCRIPTION
Summary
---
This is a batch change to apply a dependency range pin to the meta package
in order to avoid a "bad release". That version causes nearly all of our builds to
fail (anything on analyzer < 5).
So restricting the version range to <1.10.0 works around the issue until we
can upgrade to analyzer 5.

For more info, visit `#lang-dart` in Slack.

[_Created by Sourcegraph batch change `Workiva/avoid_meta_1_10_0`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/avoid_meta_1_10_0)