### PR TITLE
O11Y-3138: Improve Adherence to Specification

### DIFF
--- a/lib/src/api/open_telemetry.dart
+++ b/lib/src/api/open_telemetry.dart
@@ -3,12 +3,15 @@
 
 import 'dart:async';
 
-import '../../api.dart' as api;
-import '../../sdk.dart' as sdk;
+import 'propagation/noop_text_map_propagator.dart';
+import 'trace/noop_tracer_provider.dart';
 
-final api.TracerProvider _noopTracerProvider = sdk.TracerProviderBase();
+import '../../api.dart' as api;
+
+final api.TracerProvider _noopTracerProvider = NoopTracerProvider();
+final api.TextMapPropagator _noopTextMapPropagator = NoopTextMapPropagator();
 api.TracerProvider _tracerProvider = _noopTracerProvider;
-api.TextMapPropagator _textMapPropagator;
+api.TextMapPropagator _textMapPropagator = _noopTextMapPropagator;
 
 api.TracerProvider get globalTracerProvider => _tracerProvider;
 
@@ -25,7 +28,7 @@ void registerGlobalTracerProvider(api.TracerProvider tracerProvider) {
 }
 
 void registerGlobalTextMapPropagator(api.TextMapPropagator textMapPropagator) {
-  if (_textMapPropagator != null) {
+  if (_textMapPropagator != _noopTextMapPropagator) {
     throw StateError('A global TextMapPropagator has already been created. '
         'registerGlobalTextMapPropagator must be called only once before any '
         'calls to the getter globalTextMapPropagator.');

--- a/lib/src/api/open_telemetry.dart
+++ b/lib/src/api/open_telemetry.dart
@@ -50,7 +50,7 @@ Future<T> trace<T>(String name, Future<T> Function() fn,
     return await context.withSpan(span).execute(fn);
   } catch (e, s) {
     span
-      ..setStatus(api.StatusCode.error, description: e.toString())
+      ..setStatusCode(api.StatusCode.error, e.toString())
       ..recordException(e, stackTrace: s);
     rethrow;
   } finally {
@@ -77,7 +77,7 @@ R traceSync<R>(String name, R Function() fn,
     return r;
   } catch (e, s) {
     span
-      ..setStatus(api.StatusCode.error, description: e.toString())
+      ..setStatusCode(api.StatusCode.error, e.toString())
       ..recordException(e, stackTrace: s);
     rethrow;
   } finally {

--- a/lib/src/api/open_telemetry.dart
+++ b/lib/src/api/open_telemetry.dart
@@ -50,7 +50,7 @@ Future<T> trace<T>(String name, Future<T> Function() fn,
     return await context.withSpan(span).execute(fn);
   } catch (e, s) {
     span
-      ..setStatusCode(api.StatusCode.error, e.toString())
+      ..setStatus(api.StatusCode.error, description: e.toString())
       ..recordException(e, stackTrace: s);
     rethrow;
   } finally {
@@ -77,7 +77,7 @@ R traceSync<R>(String name, R Function() fn,
     return r;
   } catch (e, s) {
     span
-      ..setStatusCode(api.StatusCode.error, e.toString())
+      ..setStatus(api.StatusCode.error, description: e.toString())
       ..recordException(e, stackTrace: s);
     rethrow;
   } finally {

--- a/lib/src/api/propagation/noop_text_map_propagator.dart
+++ b/lib/src/api/propagation/noop_text_map_propagator.dart
@@ -1,0 +1,14 @@
+// Copyright 2021-2022 Workiva.
+// Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
+
+import '../../../api.dart' as api;
+
+class NoopTextMapPropagator implements api.TextMapPropagator {
+  @override
+  api.Context extract(
+          api.Context context, dynamic carrier, api.TextMapGetter getter) =>
+      context;
+
+  @override
+  void inject(api.Context context, dynamic carrier, api.TextMapSetter setter) {}
+}

--- a/lib/src/api/propagation/w3c_trace_context_propagator.dart
+++ b/lib/src/api/propagation/w3c_trace_context_propagator.dart
@@ -1,6 +1,8 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
+import '../trace/nonrecording_span.dart';
+
 import '../../../api.dart' as api;
 
 class W3CTraceContextPropagator implements api.TextMapPropagator {
@@ -55,7 +57,7 @@ class W3CTraceContextPropagator implements api.TextMapPropagator {
         ? api.TraceState.fromString(traceStateHeader)
         : api.TraceState.empty();
 
-    return context.withSpan(api.NonRecordingSpan(
+    return context.withSpan(NonRecordingSpan(
         api.SpanContext.remote(traceId, parentId, traceFlags, traceState)));
   }
 

--- a/lib/src/api/trace/nonrecording_span.dart
+++ b/lib/src/api/trace/nonrecording_span.dart
@@ -13,7 +13,7 @@ import '../../../api.dart' as api;
 /// This class should not be exposed to consumers and is used internally to wrap
 /// [api.SpanContext] being injected or extracted for external calls.
 @Deprecated(
-    'This class will stop being exported in a future release.  Please migrate to use of Span instead')
+    'This class will stop being exported in a future release.  Please use [api.Span] instead.')
 class NonRecordingSpan implements api.Span {
   final api.SpanStatus _status = api.SpanStatus()..code = api.StatusCode.ok;
   final api.SpanContext _spanContext;
@@ -45,7 +45,12 @@ class NonRecordingSpan implements api.Span {
   api.SpanId get parentSpanId => api.SpanId.invalid();
 
   @override
+  @Deprecated(
+      'This method will be removed in a future release.  Use [NonRecordingSpan.setStatusCode] instead.')
   void setStatus(api.StatusCode status, {String description}) {}
+
+  @override
+  void setStatusCode(api.StatusCode status, [String description]) {}
 
   @override
   api.SpanContext get spanContext => _spanContext;

--- a/lib/src/api/trace/nonrecording_span.dart
+++ b/lib/src/api/trace/nonrecording_span.dart
@@ -46,11 +46,8 @@ class NonRecordingSpan implements api.Span {
 
   @override
   @Deprecated(
-      'This method will be removed in a future release.  Use [NonRecordingSpan.setStatusCode] instead.')
+      'This method will be updated to use positional optional parameters in a future release.')
   void setStatus(api.StatusCode status, {String description}) {}
-
-  @override
-  void setStatusCode(api.StatusCode status, [String description]) {}
 
   @override
   api.SpanContext get spanContext => _spanContext;

--- a/lib/src/api/trace/nonrecording_span.dart
+++ b/lib/src/api/trace/nonrecording_span.dart
@@ -13,7 +13,7 @@ import '../../../api.dart' as api;
 /// This class should not be exposed to consumers and is used internally to wrap
 /// [api.SpanContext] being injected or extracted for external calls.
 @Deprecated(
-    'This class will stop being exported in a future release.  Please use [api.Span] instead.')
+    'This class will stop being exported in v0.18.0.  Please use [api.Span] instead.')
 class NonRecordingSpan implements api.Span {
   final api.SpanStatus _status = api.SpanStatus()..code = api.StatusCode.ok;
   final api.SpanContext _spanContext;
@@ -46,7 +46,7 @@ class NonRecordingSpan implements api.Span {
 
   @override
   @Deprecated(
-      'This method will be updated to use positional optional parameters in a future release.')
+      'This method will be updated to use positional optional parameters in v0.18.0.')
   void setStatus(api.StatusCode status, {String description}) {}
 
   @override

--- a/lib/src/api/trace/nonrecording_span.dart
+++ b/lib/src/api/trace/nonrecording_span.dart
@@ -12,6 +12,8 @@ import '../../../api.dart' as api;
 ///
 /// This class should not be exposed to consumers and is used internally to wrap
 /// [api.SpanContext] being injected or extracted for external calls.
+@Deprecated(
+    'This class will stop being exported in a future release.  Please migrate to use of Span instead')
 class NonRecordingSpan implements api.Span {
   final api.SpanStatus _status = api.SpanStatus()..code = api.StatusCode.ok;
   final api.SpanContext _spanContext;

--- a/lib/src/api/trace/noop_tracer.dart
+++ b/lib/src/api/trace/noop_tracer.dart
@@ -4,9 +4,9 @@
 import 'package:fixnum/fixnum.dart';
 
 import '../../../api.dart' as api;
-import '../../../sdk.dart' as sdk;
+import 'nonrecording_span.dart';
 
-/// A [api.Tracer] class which yields [api.NonRecordingSpan]s and no-ops for most
+/// A [api.Tracer] class which yields [NonRecordingSpan]s and no-ops for most
 /// operations.
 class NoopTracer implements api.Tracer {
   @override
@@ -16,9 +16,11 @@ class NoopTracer implements api.Tracer {
       List<api.Attribute> attributes,
       List<api.SpanLink> links,
       Int64 startTime}) {
-    final parentContext = context.spanContext;
+    final parentContext =
+        (context.spanContext != null && context.spanContext.isValid)
+            ? context.spanContext
+            : api.SpanContext.invalid();
 
-    return api.NonRecordingSpan(
-        (parentContext.isValid) ? parentContext : sdk.SpanContext.invalid());
+    return NonRecordingSpan(parentContext);
   }
 }

--- a/lib/src/api/trace/noop_tracer_provider.dart
+++ b/lib/src/api/trace/noop_tracer_provider.dart
@@ -1,0 +1,18 @@
+// Copyright 2021-2022 Workiva.
+// Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
+
+import '../../../api.dart' as api;
+import 'noop_tracer.dart';
+
+class NoopTracerProvider implements api.TracerProvider {
+  @override
+  void forceFlush() {}
+
+  @override
+  api.Tracer getTracer(String name, {String version}) {
+    return NoopTracer();
+  }
+
+  @override
+  void shutdown() {}
+}

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -28,6 +28,8 @@ enum SpanKind {
 /// function calls to sub-components. A trace has a single, top-level "root"
 /// span that in turn may haze zero or more child Spans, which in turn may have
 /// children.
+///
+/// Warning: methods may be added to this interface in minor releases.
 abstract class Span {
   /// The context associated with this span.
   ///
@@ -63,17 +65,8 @@ abstract class Span {
   /// Only the value of the last call will be recorded, and implementations are
   /// free to ignore previous calls.
   @Deprecated(
-      'This method will be removed in a future release.  Use [Span.setStatusCode] instead.')
+      'This method will be updated to use positional optional parameters in a future release.')
   void setStatus(api.StatusCode status, {String description});
-
-  /// Sets the status to the [Span].
-  ///
-  /// If used, this will override the default [Span] status. Default status code
-  /// is [api.StatusCode.unset].
-  ///
-  /// Only the value of the last call will be recorded, and implementations are
-  /// free to ignore previous calls.
-  void setStatusCode(api.StatusCode status, [String description]);
 
   /// Retrieve the status of the [Span].
   api.SpanStatus get status;

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -65,7 +65,7 @@ abstract class Span {
   /// Only the value of the last call will be recorded, and implementations are
   /// free to ignore previous calls.
   @Deprecated(
-      'This method will be updated to use positional optional parameters in a future release.')
+      'This method will be updated to use positional optional parameters in v0.18.0.')
   void setStatus(api.StatusCode status, {String description});
 
   /// Retrieve the status of the [Span].

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -51,7 +51,7 @@ abstract class Span {
   String name;
 
   /// Whether this Span is recording information like events with the
-  /// addEvent operation, status with setStatusCode, etc.
+  /// addEvent operation, status with setStatus, etc.
   bool get isRecording;
 
   /// The kind of the span.

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -49,7 +49,7 @@ abstract class Span {
   String name;
 
   /// Whether this Span is recording information like events with the
-  /// addEvent operation, status with setStatus, etc.
+  /// addEvent operation, status with setStatusCode, etc.
   bool get isRecording;
 
   /// The kind of the span.
@@ -62,7 +62,18 @@ abstract class Span {
   ///
   /// Only the value of the last call will be recorded, and implementations are
   /// free to ignore previous calls.
+  @Deprecated(
+      'This method will be removed in a future release.  Use [Span.setStatusCode] instead.')
   void setStatus(api.StatusCode status, {String description});
+
+  /// Sets the status to the [Span].
+  ///
+  /// If used, this will override the default [Span] status. Default status code
+  /// is [api.StatusCode.unset].
+  ///
+  /// Only the value of the last call will be recorded, and implementations are
+  /// free to ignore previous calls.
+  void setStatusCode(api.StatusCode status, [String description]);
 
   /// Retrieve the status of the [Span].
   api.SpanStatus get status;

--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -9,6 +9,8 @@ import '../../../api.dart' as api;
 ///
 /// Users may choose to use manual or automatic Context propagation. Because of
 /// that, this class offers APIs to facilitate both usages.
+///
+/// Warning: methods may be added to this interface in minor releases.
 abstract class Tracer {
   /// Starts a new [api.Span] without setting it as the current span in this
   /// tracer's context.

--- a/lib/src/api/trace/tracer_provider.dart
+++ b/lib/src/api/trace/tracer_provider.dart
@@ -4,6 +4,8 @@
 import '../../../api.dart' as api;
 
 /// A registry for creating named [api.Tracer]s.
+///
+/// Warning: methods may be added to this interface in minor releases.
 abstract class TracerProvider {
   /// Returns a Tracer, creating one if one with the given [name] and [version]
   /// is not already created.

--- a/lib/src/sdk/platforms/web/trace/web_tracer_provider.dart
+++ b/lib/src/sdk/platforms/web/trace/web_tracer_provider.dart
@@ -16,13 +16,7 @@ import '../../../trace/tracer.dart';
 /// See https://github.com/open-telemetry/opentelemetry-js/issues/852
 /// for more information.
 class WebTracerProvider extends sdk.TracerProviderBase {
-  final Map<String, api.Tracer> _tracers = {};
-  final List<api.SpanProcessor> _processors;
-  final sdk.Resource _resource;
-  final sdk.Sampler _sampler;
   final sdk.TimeProvider _timeProvider;
-  final api.IdGenerator _idGenerator;
-  final sdk.SpanLimits _spanLimits;
 
   WebTracerProvider(
       {List<api.SpanProcessor> processors,
@@ -33,25 +27,20 @@ class WebTracerProvider extends sdk.TracerProviderBase {
       sdk.SpanLimits spanLimits})
       :
         // Default to a no-op TracerProvider.
-        _processors = processors ?? [],
-        _resource = resource ?? sdk.Resource([]),
-        _sampler = sampler ?? sdk.ParentBasedSampler(sdk.AlwaysOnSampler()),
         _timeProvider = timeProvider ?? sdk.DateTimeTimeProvider(),
-        _idGenerator = idGenerator ?? sdk.IdGenerator(),
-        _spanLimits = spanLimits ?? sdk.SpanLimits(),
         super(
-            processors: processors,
-            resource: resource,
-            sampler: sampler,
-            idGenerator: idGenerator,
-            spanLimits: spanLimits);
+            processors: processors ?? [],
+            resource: resource ?? sdk.Resource([]),
+            sampler: sampler ?? sdk.ParentBasedSampler(sdk.AlwaysOnSampler()),
+            idGenerator: idGenerator ?? sdk.IdGenerator(),
+            spanLimits: spanLimits ?? sdk.SpanLimits());
 
   @override
   api.Tracer getTracer(String name, {String version = ''}) {
-    return _tracers.putIfAbsent(
+    return tracers.putIfAbsent(
         '$name@$version',
-        () => Tracer(_processors, _resource, _sampler, _timeProvider,
-            _idGenerator, sdk.InstrumentationLibrary(name, version),
-            spanLimits: _spanLimits));
+        () => Tracer(processors, resource, sampler, _timeProvider, idGenerator,
+            sdk.InstrumentationLibrary(name, version),
+            spanLimits: spanLimits));
   }
 }

--- a/lib/src/sdk/trace/sampling/always_off_sampler.dart
+++ b/lib/src/sdk/trace/sampling/always_off_sampler.dart
@@ -17,6 +17,6 @@ class AlwaysOffSampler implements sdk.Sampler {
       List<api.Attribute> spanAttributes,
       List<api.SpanLink> links) {
     return sdk.SamplingResult(sdk.Decision.drop, spanAttributes,
-        context.spanContext?.traceState ?? sdk.TraceState.empty());
+        context.spanContext?.traceState ?? api.TraceState.empty());
   }
 }

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -79,24 +79,8 @@ class Span implements api.Span {
 
   @override
   @Deprecated(
-      'This method will be removed in a future release.  Use [Span.setStatusCode] instead.')
+      'This method will be updated to use positional optional parameters in a future release.')
   void setStatus(api.StatusCode status, {String description}) {
-    // A status cannot be Unset after being set, and cannot be set to any other
-    // status after being marked "Ok".
-    if (status == api.StatusCode.unset || _status.code == api.StatusCode.ok) {
-      return;
-    }
-
-    _status.code = status;
-
-    // Description is ignored for statuses other than "Error".
-    if (status == api.StatusCode.error && description != null) {
-      _status.description = description;
-    }
-  }
-
-  @override
-  void setStatusCode(api.StatusCode status, [String description]) {
     // A status cannot be Unset after being set, and cannot be set to any other
     // status after being marked "Ok".
     if (status == api.StatusCode.unset || _status.code == api.StatusCode.ok) {

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -8,6 +8,8 @@ import '../../../sdk.dart' as sdk;
 import '../common/attributes.dart';
 
 /// A representation of a single operation within a trace.
+@Deprecated(
+    'This class will stop being exported and be marked protected in a future release.  Consumers should use [api.Span] instead.')
 class Span implements api.Span {
   final api.SpanContext _spanContext;
   final api.SpanId _parentSpanId;
@@ -31,6 +33,8 @@ class Span implements api.Span {
   bool get isRecording => _endTime == null;
 
   /// Construct a [Span].
+  @Deprecated(
+      'This constructor will be marked protected in a future release.  Consumers should use [api.Span] instead.')
   Span(this.name, this._spanContext, this._parentSpanId, this._processors,
       this._timeProvider, this._resource, this._instrumentationLibrary,
       {api.SpanKind kind,
@@ -74,7 +78,25 @@ class Span implements api.Span {
   }
 
   @override
+  @Deprecated(
+      'This method will be removed in a future release.  Use [Span.setStatusCode] instead.')
   void setStatus(api.StatusCode status, {String description}) {
+    // A status cannot be Unset after being set, and cannot be set to any other
+    // status after being marked "Ok".
+    if (status == api.StatusCode.unset || _status.code == api.StatusCode.ok) {
+      return;
+    }
+
+    _status.code = status;
+
+    // Description is ignored for statuses other than "Error".
+    if (status == api.StatusCode.error && description != null) {
+      _status.description = description;
+    }
+  }
+
+  @override
+  void setStatusCode(api.StatusCode status, [String description]) {
     // A status cannot be Unset after being set, and cannot be set to any other
     // status after being marked "Ok".
     if (status == api.StatusCode.unset || _status.code == api.StatusCode.ok) {

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -9,7 +9,7 @@ import '../common/attributes.dart';
 
 /// A representation of a single operation within a trace.
 @Deprecated(
-    'This class will stop being exported and be marked protected in a future release.  Consumers should use [api.Span] instead.')
+    'This class will stop being exported and be marked protected in v0.18.0.  Consumers should use [api.Span] instead.')
 class Span implements api.Span {
   final api.SpanContext _spanContext;
   final api.SpanId _parentSpanId;
@@ -34,7 +34,7 @@ class Span implements api.Span {
 
   /// Construct a [Span].
   @Deprecated(
-      'This constructor will be marked protected in a future release.  Consumers should use [api.Span] instead.')
+      'This constructor will be marked protected in v0.18.0.  Consumers should use [api.Span] instead.')
   Span(this.name, this._spanContext, this._parentSpanId, this._processors,
       this._timeProvider, this._resource, this._instrumentationLibrary,
       {api.SpanKind kind,
@@ -79,7 +79,7 @@ class Span implements api.Span {
 
   @override
   @Deprecated(
-      'This method will be updated to use positional optional parameters in a future release.')
+      'This method will be updated to use positional optional parameters in v0.18.0.')
   void setStatus(api.StatusCode status, {String description}) {
     // A status cannot be Unset after being set, and cannot be set to any other
     // status after being marked "Ok".

--- a/lib/src/sdk/trace/span_limits.dart
+++ b/lib/src/sdk/trace/span_limits.dart
@@ -2,19 +2,19 @@
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
 class SpanLimits {
-  final _DEFAULT_MAXNUM_ATTRIBUTES = 128;
-  final _DEFAULT_MAXNUM_EVENTS = 128;
-  final _DEFAULT_MAXNUM_LINKS = 128;
-  final _DEFAULT_MAXNUM_ATTRIBUTE_PER_EVENT = 128;
-  final _DEFAULT_MAXNUM_ATTRIBUTES_PER_LINK = 128;
-  final _DEFAULT_MAXNUM_ATTRIBUTES_LENGTH = -1;
+  static const _DEFAULT_MAXNUM_ATTRIBUTES = 128;
+  static const _DEFAULT_MAXNUM_EVENTS = 128;
+  static const _DEFAULT_MAXNUM_LINKS = 128;
+  static const _DEFAULT_MAXNUM_ATTRIBUTE_PER_EVENT = 128;
+  static const _DEFAULT_MAXNUM_ATTRIBUTES_PER_LINK = 128;
+  static const _DEFAULT_MAXNUM_ATTRIBUTES_LENGTH = -1;
 
-  int _maxNumAttributes;
-  int _maxNumEvents;
-  int _maxNumLink;
-  int _maxNumAttributesPerEvent;
-  int _maxNumAttributesPerLink;
-  int _maxNumAttributeLength;
+  final int _maxNumAttributes;
+  final int _maxNumEvents;
+  final int _maxNumLink;
+  final int _maxNumAttributesPerEvent;
+  final int _maxNumAttributesPerLink;
+  final int _maxNumAttributeLength;
 
   ///setters
   ///Set the max number of attributes per span
@@ -89,21 +89,20 @@ class SpanLimits {
   ///constructor
   ///https://docs.newrelic.com/docs/data-apis/manage-data/view-system-limits/
   ///https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SpanLimitsBuilder.java
-  SpanLimits(
+  const SpanLimits(
       {int maxNumAttributes,
       int maxNumEvents,
       int maxNumLink,
       int maxNumAttributesPerEvent,
       int maxNumAttributesPerLink,
-      int maxNumAttributeLength}) {
-    _maxNumAttributes = maxNumAttributes ?? _DEFAULT_MAXNUM_ATTRIBUTES;
-    _maxNumEvents = maxNumEvents ?? _DEFAULT_MAXNUM_EVENTS;
-    _maxNumLink = maxNumLink ?? _DEFAULT_MAXNUM_LINKS;
-    _maxNumAttributesPerEvent =
-        maxNumAttributesPerEvent ?? _DEFAULT_MAXNUM_ATTRIBUTE_PER_EVENT;
-    _maxNumAttributesPerLink =
-        maxNumAttributesPerLink ?? _DEFAULT_MAXNUM_ATTRIBUTES_PER_LINK;
-    _maxNumAttributeLength =
-        maxNumAttributeLength ?? _DEFAULT_MAXNUM_ATTRIBUTES_LENGTH;
-  }
+      int maxNumAttributeLength})
+      : _maxNumAttributes = maxNumAttributes ?? _DEFAULT_MAXNUM_ATTRIBUTES,
+        _maxNumEvents = maxNumEvents ?? _DEFAULT_MAXNUM_EVENTS,
+        _maxNumLink = maxNumLink ?? _DEFAULT_MAXNUM_LINKS,
+        _maxNumAttributesPerEvent =
+            maxNumAttributesPerEvent ?? _DEFAULT_MAXNUM_ATTRIBUTE_PER_EVENT,
+        _maxNumAttributesPerLink =
+            maxNumAttributesPerLink ?? _DEFAULT_MAXNUM_ATTRIBUTES_PER_LINK,
+        _maxNumAttributeLength =
+            maxNumAttributeLength ?? _DEFAULT_MAXNUM_ATTRIBUTES_LENGTH;
 }

--- a/lib/src/sdk/trace/tracer.dart
+++ b/lib/src/sdk/trace/tracer.dart
@@ -48,7 +48,7 @@ class Tracer implements api.Tracer {
     } else {
       parentSpanId = api.SpanId.root();
       traceId = api.TraceId.fromIdGenerator(_idGenerator);
-      traceState = sdk.TraceState.empty();
+      traceState = api.TraceState.empty();
     }
 
     final samplerResult =
@@ -57,7 +57,7 @@ class Tracer implements api.Tracer {
         ? api.TraceFlags.sampled
         : api.TraceFlags.none;
     final spanContext =
-        sdk.SpanContext(traceId, spanId, traceFlags, traceState);
+        api.SpanContext(traceId, spanId, traceFlags, traceState);
 
     return Span(name, spanContext, parentSpanId, _processors, _timeProvider,
         _resource, _instrumentationLibrary,

--- a/lib/src/sdk/trace/tracer.dart
+++ b/lib/src/sdk/trace/tracer.dart
@@ -18,7 +18,7 @@ class Tracer implements api.Tracer {
   final sdk.SpanLimits _spanLimits;
 
   @Deprecated(
-      'This constructor will be marked protected in a future release.  Consumers should use [api.Tracer] instead.')
+      'This constructor will be marked protected in v0.18.0.  Consumers should use [api.Tracer] instead.')
   Tracer(this._processors, this._resource, this._sampler, this._timeProvider,
       this._idGenerator, this._instrumentationLibrary,
       {sdk.SpanLimits spanLimits})

--- a/lib/src/sdk/trace/tracer.dart
+++ b/lib/src/sdk/trace/tracer.dart
@@ -17,6 +17,8 @@ class Tracer implements api.Tracer {
   final api.InstrumentationLibrary _instrumentationLibrary;
   final sdk.SpanLimits _spanLimits;
 
+  @Deprecated(
+      'This constructor will be marked protected in a future release.  Consumers should use [api.Tracer] instead.')
   Tracer(this._processors, this._resource, this._sampler, this._timeProvider,
       this._idGenerator, this._instrumentationLibrary,
       {sdk.SpanLimits spanLimits})

--- a/lib/src/sdk/trace/tracer_provider.dart
+++ b/lib/src/sdk/trace/tracer_provider.dart
@@ -1,18 +1,31 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
+import 'package:meta/meta.dart';
+
 import './tracer.dart';
 import '../../../api.dart' as api;
 import '../../../sdk.dart' as sdk;
 
 /// A registry for creating named [api.Tracer]s.
 class TracerProviderBase implements api.TracerProvider {
-  final Map<String, api.Tracer> _tracers = {};
-  final List<api.SpanProcessor> _processors;
-  final sdk.Resource _resource;
-  final sdk.Sampler _sampler;
-  final api.IdGenerator _idGenerator;
-  final sdk.SpanLimits _spanLimits;
+  @protected
+  final Map<String, api.Tracer> tracers = {};
+
+  @protected
+  final List<api.SpanProcessor> processors;
+
+  @protected
+  final sdk.Resource resource;
+
+  @protected
+  final sdk.Sampler sampler;
+
+  @protected
+  final api.IdGenerator idGenerator;
+
+  @protected
+  final sdk.SpanLimits spanLimits;
 
   TracerProviderBase(
       {List<api.SpanProcessor> processors,
@@ -20,40 +33,35 @@ class TracerProviderBase implements api.TracerProvider {
       sdk.Sampler sampler,
       api.IdGenerator idGenerator,
       sdk.SpanLimits spanLimits})
-      : _processors = processors ?? [], // Default to a no-op TracerProvider.
-        _resource = resource ?? sdk.Resource([]),
-        _sampler = sampler ?? sdk.ParentBasedSampler(sdk.AlwaysOnSampler()),
-        _idGenerator = idGenerator ?? sdk.IdGenerator(),
-        _spanLimits = spanLimits ?? sdk.SpanLimits();
+      : processors = processors ?? [], // Default to a no-op TracerProvider.
+        resource = resource ?? sdk.Resource([]),
+        sampler = sampler ?? sdk.ParentBasedSampler(sdk.AlwaysOnSampler()),
+        idGenerator = idGenerator ?? sdk.IdGenerator(),
+        spanLimits = spanLimits ?? sdk.SpanLimits();
 
-  List<api.SpanProcessor> get spanProcessors => _processors;
+  List<api.SpanProcessor> get spanProcessors => processors;
 
   @override
   api.Tracer getTracer(String name, {String version = ''}) {
     final key = '$name@$version';
-    return _tracers.putIfAbsent(
+    return tracers.putIfAbsent(
         key,
-        () => Tracer(
-            _processors,
-            _resource,
-            _sampler,
-            sdk.DateTimeTimeProvider(),
-            _idGenerator,
-            sdk.InstrumentationLibrary(name, version),
-            spanLimits: _spanLimits));
+        () => Tracer(processors, resource, sampler, sdk.DateTimeTimeProvider(),
+            idGenerator, sdk.InstrumentationLibrary(name, version),
+            spanLimits: spanLimits));
   }
 
   @override
   void forceFlush() {
-    for (var i = 0; i < _processors.length; i++) {
-      _processors[i].forceFlush();
+    for (var i = 0; i < processors.length; i++) {
+      processors[i].forceFlush();
     }
   }
 
   @override
   void shutdown() {
-    for (var i = 0; i < _processors.length; i++) {
-      _processors[i].shutdown();
+    for (var i = 0; i < processors.length; i++) {
+      processors[i].shutdown();
     }
   }
 }

--- a/test/integration/sdk/propagation/w3c_trace_context_propagator_test.dart
+++ b/test/integration/sdk/propagation/w3c_trace_context_propagator_test.dart
@@ -32,11 +32,11 @@ void main() {
   test('inject and extract trace context', () {
     final testSpan = Span(
         'TestSpan',
-        sdk.SpanContext(
+        api.SpanContext(
             api.TraceId.fromString('4bf92f3577b34da6a3ce929d0e0e4736'),
             api.SpanId.fromString('0000000000c0ffee'),
             api.TraceFlags.sampled,
-            sdk.TraceState.fromString(
+            api.TraceState.fromString(
                 'rojo=00f067aa0ba902b7,congo=t61rcWkgMzE')),
         api.SpanId.fromString('00f067aa0ba902b7'),
         [],
@@ -58,8 +58,7 @@ void main() {
         resultSpan.spanContext.spanId.toString(), equals('0000000000c0ffee'));
     expect(resultSpan.spanContext.traceId.toString(),
         equals('4bf92f3577b34da6a3ce929d0e0e4736'));
-    expect((resultSpan.spanContext as sdk.SpanContext).traceFlags,
-        equals(api.TraceFlags.sampled));
+    expect(resultSpan.spanContext.traceFlags, equals(api.TraceFlags.sampled));
     expect(resultSpan.spanContext.traceState.toString(),
         equals('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'));
   });
@@ -67,11 +66,11 @@ void main() {
   test('inject and extract invalid trace parent', () {
     final testSpan = Span(
         'TestSpan',
-        sdk.SpanContext(
+        api.SpanContext(
             api.TraceId.fromString('00000000000000000000000000000000'),
             api.SpanId.fromString('0000000000c0ffee'),
             api.TraceFlags.none,
-            sdk.TraceState.fromString(
+            api.TraceState.fromString(
                 'rojo=00f067aa0ba902b7,congo=t61rcWkgMzE')),
         api.SpanId.fromString('0000000000000000'),
         [],
@@ -93,8 +92,7 @@ void main() {
         resultSpan.spanContext.spanId.toString(), equals('0000000000c0ffee'));
     expect(resultSpan.spanContext.traceId.toString(),
         equals('00000000000000000000000000000000'));
-    expect((resultSpan.spanContext as sdk.SpanContext).traceFlags,
-        equals(api.TraceFlags.none));
+    expect(resultSpan.spanContext.traceFlags, equals(api.TraceFlags.none));
     expect(resultSpan.spanContext.traceState.toString(),
         equals('rojo=00f067aa0ba902b7,congo=t61rcWkgMzE'));
   });
@@ -102,11 +100,11 @@ void main() {
   test('extract and inject with child span', () {
     final testSpan = Span(
         'TestSpan',
-        sdk.SpanContext(
+        api.SpanContext(
             api.TraceId.fromString('4bf92f3577b34da6a3ce929d0e0e4736'),
             api.SpanId.fromString('0000000000c0ffee'),
             api.TraceFlags.sampled,
-            sdk.TraceState.fromString(
+            api.TraceState.fromString(
                 'rojo=00f067aa0ba902b7,congo=t61rcWkgMzE')),
         api.SpanId.fromString('00f067aa0ba902b7'),
         [],

--- a/test/integration/sdk/span_context_test.dart
+++ b/test/integration/sdk/span_context_test.dart
@@ -11,7 +11,7 @@ void main() {
     final spanId = api.SpanId([1, 2, 3]);
     final traceId = api.TraceId([4, 5, 6]);
     const traceFlags = api.TraceFlags.sampled;
-    final traceState = sdk.TraceState.empty();
+    final traceState = api.TraceState.empty();
 
     final testSpanContext =
         sdk.SpanContext(traceId, spanId, traceFlags, traceState);
@@ -28,7 +28,7 @@ void main() {
     final spanId = api.SpanId.fromString('0000000000000000');
     final traceId = api.TraceId([4, 5, 6]);
     const traceFlags = api.TraceFlags.sampled;
-    final traceState = sdk.TraceState.empty();
+    final traceState = api.TraceState.empty();
 
     final testSpanContext =
         sdk.SpanContext(traceId, spanId, traceFlags, traceState);
@@ -44,7 +44,7 @@ void main() {
     final spanId = api.SpanId([1, 2, 3]);
     final traceId = api.TraceId.fromString('00000000000000000000000000000000');
     const traceFlags = api.TraceFlags.sampled;
-    final traceState = sdk.TraceState.empty();
+    final traceState = api.TraceState.empty();
 
     final testSpanContext =
         sdk.SpanContext(traceId, spanId, traceFlags, traceState);
@@ -57,7 +57,7 @@ void main() {
   });
 
   test('valid context evaluates as valid', () {
-    final testSpanContext = sdk.SpanContext.invalid();
+    final testSpanContext = api.SpanContext.invalid();
 
     expect(testSpanContext.isValid, isFalse);
     expect(testSpanContext.traceId.isValid, isFalse);

--- a/test/integration/sdk/span_test.dart
+++ b/test/integration/sdk/span_test.dart
@@ -60,32 +60,30 @@ void main() {
     expect(span.status.description, equals(null));
 
     // Verify that span status can be set to "Error".
-    span.setStatus(api.StatusCode.error, description: 'Something s\'ploded.');
+    span.setStatusCode(api.StatusCode.error, 'Something s\'ploded.');
     expect(span.status.code, equals(api.StatusCode.error));
     expect(span.status.description, equals('Something s\'ploded.'));
 
     // Verify that multiple errors update the span to the most recently set.
-    span.setStatus(api.StatusCode.error,
-        description: 'Another error happened.');
+    span.setStatusCode(api.StatusCode.error, 'Another error happened.');
     expect(span.status.code, equals(api.StatusCode.error));
     expect(span.status.description, equals('Another error happened.'));
 
     // Verify that span status cannot be set to "Unset" and that description
     // is ignored for statuses other than "Error".
-    span.setStatus(api.StatusCode.unset,
-        description: 'Oops.  Can we turn this back off?');
+    span.setStatusCode(
+        api.StatusCode.unset, 'Oops.  Can we turn this back off?');
     expect(span.status.code, equals(api.StatusCode.error));
     expect(span.status.description, equals('Another error happened.'));
 
     // Verify that span status can be set to "Ok" and that description is
     // ignored for statuses other than "Error".
-    span.setStatus(api.StatusCode.ok, description: 'All done here.');
+    span.setStatusCode(api.StatusCode.ok, 'All done here.');
     expect(span.status.code, equals(api.StatusCode.ok));
     expect(span.status.description, equals('Another error happened.'));
 
     // Verify that span status cannot be changed once set to "Ok".
-    span.setStatus(api.StatusCode.error,
-        description: 'Something else went wrong.');
+    span.setStatusCode(api.StatusCode.error, 'Something else went wrong.');
     expect(span.status.code, equals(api.StatusCode.ok));
     expect(span.status.description, equals('Another error happened.'));
   });

--- a/test/integration/sdk/span_test.dart
+++ b/test/integration/sdk/span_test.dart
@@ -60,30 +60,32 @@ void main() {
     expect(span.status.description, equals(null));
 
     // Verify that span status can be set to "Error".
-    span.setStatusCode(api.StatusCode.error, 'Something s\'ploded.');
+    span.setStatus(api.StatusCode.error, description: 'Something s\'ploded.');
     expect(span.status.code, equals(api.StatusCode.error));
     expect(span.status.description, equals('Something s\'ploded.'));
 
     // Verify that multiple errors update the span to the most recently set.
-    span.setStatusCode(api.StatusCode.error, 'Another error happened.');
+    span.setStatus(api.StatusCode.error,
+        description: 'Another error happened.');
     expect(span.status.code, equals(api.StatusCode.error));
     expect(span.status.description, equals('Another error happened.'));
 
     // Verify that span status cannot be set to "Unset" and that description
     // is ignored for statuses other than "Error".
-    span.setStatusCode(
-        api.StatusCode.unset, 'Oops.  Can we turn this back off?');
+    span.setStatus(api.StatusCode.unset,
+        description: 'Oops.  Can we turn this back off?');
     expect(span.status.code, equals(api.StatusCode.error));
     expect(span.status.description, equals('Another error happened.'));
 
     // Verify that span status can be set to "Ok" and that description is
     // ignored for statuses other than "Error".
-    span.setStatusCode(api.StatusCode.ok, 'All done here.');
+    span.setStatus(api.StatusCode.ok, description: 'All done here.');
     expect(span.status.code, equals(api.StatusCode.ok));
     expect(span.status.description, equals('Another error happened.'));
 
     // Verify that span status cannot be changed once set to "Ok".
-    span.setStatusCode(api.StatusCode.error, 'Something else went wrong.');
+    span.setStatus(api.StatusCode.error,
+        description: 'Something else went wrong.');
     expect(span.status.code, equals(api.StatusCode.ok));
     expect(span.status.description, equals('Another error happened.'));
   });

--- a/test/integration/sdk/span_test.dart
+++ b/test/integration/sdk/span_test.dart
@@ -17,8 +17,8 @@ void main() {
     final parentSpanId = api.SpanId([4, 5, 6]);
     final span = Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         parentSpanId,
         [mockProcessor1, mockProcessor2],
         sdk.DateTimeTimeProvider(),
@@ -47,8 +47,8 @@ void main() {
   test('span status', () {
     final span = Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),
@@ -113,8 +113,8 @@ void main() {
     };
     final span = Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),
@@ -137,8 +137,8 @@ void main() {
   test('span record error', () {
     final span = Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),

--- a/test/unit/api/context_test.dart
+++ b/test/unit/api/context_test.dart
@@ -8,8 +8,8 @@ import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final testSpanContext = sdk.SpanContext(api.TraceId([1, 2, 3]),
-      api.SpanId([7, 8, 9]), api.TraceFlags.none, sdk.TraceState.empty());
+  final testSpanContext = api.SpanContext(api.TraceId([1, 2, 3]),
+      api.SpanId([7, 8, 9]), api.TraceFlags.none, api.TraceState.empty());
   final testSpan = Span(
       'foo',
       testSpanContext,

--- a/test/unit/sdk/exporters/collector_exporter_test.dart
+++ b/test/unit/sdk/exporters/collector_exporter_test.dart
@@ -39,8 +39,8 @@ void main() {
     final limits = sdk.SpanLimits(maxNumAttributeLength: 5);
     final span1 = Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),
@@ -51,8 +51,8 @@ void main() {
       ..end();
     final span2 = Span(
         'baz',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([10, 11, 12]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([10, 11, 12]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),
@@ -140,8 +140,8 @@ void main() {
   test('does not send spans when shutdown', () {
     final span = Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),
@@ -161,8 +161,8 @@ void main() {
   test('supplies HTTP headers', () {
     final span = Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),
@@ -189,8 +189,8 @@ void main() {
   test('does not supply HTTP headers', () {
     final span = Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),

--- a/test/unit/sdk/exporters/console_exporter_test.dart
+++ b/test/unit/sdk/exporters/console_exporter_test.dart
@@ -27,8 +27,8 @@ void main() {
   test('prints', overridePrint(() {
     final span = Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),
@@ -47,8 +47,8 @@ void main() {
   test('does not print after shutdown', overridePrint(() {
     final span = Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),

--- a/test/unit/sdk/platforms/web/web_time_provider_test.dart
+++ b/test/unit/sdk/platforms/web/web_time_provider_test.dart
@@ -12,8 +12,8 @@ void main() {
   test('records start and end times with browser performance API', () async {
     final span = Span(
         'testStartAndEndTimes',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         WebTimeProvider(),

--- a/test/unit/sdk/platforms/web/web_trace_provider_test.dart
+++ b/test/unit/sdk/platforms/web/web_trace_provider_test.dart
@@ -61,7 +61,7 @@ void main() {
     final span = WebTracerProvider(processors: [MockSpanProcessor()])
         .getTracer('testTracer')
         .startSpan('testSpan', context: Context.root)
-      ..end();
+          ..end();
 
     expect(span.startTime, lessThanOrEqualTo(span.endTime));
   });

--- a/test/unit/sdk/platforms/web/web_trace_provider_test.dart
+++ b/test/unit/sdk/platforms/web/web_trace_provider_test.dart
@@ -61,7 +61,7 @@ void main() {
     final span = WebTracerProvider(processors: [MockSpanProcessor()])
         .getTracer('testTracer')
         .startSpan('testSpan', context: Context.root)
-          ..end();
+      ..end();
 
     expect(span.startTime, lessThanOrEqualTo(span.endTime));
   });

--- a/test/unit/sdk/sampling/always_off_sampler_test.dart
+++ b/test/unit/sdk/sampling/always_off_sampler_test.dart
@@ -10,10 +10,10 @@ import 'package:test/test.dart';
 void main() {
   test('Context contains a Span', () {
     final traceId = api.TraceId([1, 2, 3]);
-    final traceState = sdk.TraceState.fromString('test=onetwo');
+    final traceState = api.TraceState.fromString('test=onetwo');
     final testSpan = Span(
         'foo',
-        sdk.SpanContext(
+        api.SpanContext(
             traceId, api.SpanId([7, 8, 9]), api.TraceFlags.none, traceState),
         api.SpanId([4, 5, 6]),
         [],
@@ -38,8 +38,8 @@ void main() {
     ];
     final testSpan = Span(
         'foo',
-        sdk.SpanContext(traceId, api.SpanId([7, 8, 9]), api.TraceFlags.none,
-            sdk.TraceState.empty()),
+        api.SpanContext(traceId, api.SpanId([7, 8, 9]), api.TraceFlags.none,
+            api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),

--- a/test/unit/sdk/sampling/always_on_sampler_test.dart
+++ b/test/unit/sdk/sampling/always_on_sampler_test.dart
@@ -10,10 +10,10 @@ import 'package:test/test.dart';
 void main() {
   test('Context contains a Span', () {
     final traceId = api.TraceId([1, 2, 3]);
-    final traceState = sdk.TraceState.fromString('test=onetwo');
+    final traceState = api.TraceState.fromString('test=onetwo');
     final testSpan = Span(
         'foo',
-        sdk.SpanContext(
+        api.SpanContext(
             traceId, api.SpanId([7, 8, 9]), api.TraceFlags.none, traceState),
         api.SpanId([4, 5, 6]),
         [],
@@ -34,8 +34,8 @@ void main() {
     final traceId = api.TraceId([1, 2, 3]);
     final testSpan = Span(
         'foo',
-        sdk.SpanContext(traceId, api.SpanId([7, 8, 9]), api.TraceFlags.none,
-            sdk.TraceState.empty()),
+        api.SpanContext(traceId, api.SpanId([7, 8, 9]), api.TraceFlags.none,
+            api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),

--- a/test/unit/sdk/sampling/parent_based_sampler_test.dart
+++ b/test/unit/sdk/sampling/parent_based_sampler_test.dart
@@ -20,7 +20,7 @@ void main() {
   test('Invalid parent span context', () {
     final testSpan = Span(
         'test',
-        sdk.SpanContext.invalid(),
+        api.SpanContext.invalid(),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),
@@ -41,7 +41,7 @@ void main() {
   test('Missing parent span context', () {
     final testSpan = Span(
         'test',
-        sdk.SpanContext.invalid(),
+        api.SpanContext.invalid(),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),
@@ -59,10 +59,10 @@ void main() {
 
   test('with sampled, remote sdk.Span', () {
     final traceId = api.TraceId([1, 2, 3]);
-    final traceState = sdk.TraceState.fromString('test=onetwo');
+    final traceState = api.TraceState.fromString('test=onetwo');
     final testSpan = Span(
         'foo',
-        sdk.SpanContext.remote(
+        api.SpanContext.remote(
             traceId, api.SpanId([7, 8, 9]), api.TraceFlags.sampled, traceState),
         api.SpanId([4, 5, 6]),
         [],
@@ -82,10 +82,10 @@ void main() {
 
   test('with non-sampled, remote sdk.Span', () {
     final traceId = api.TraceId([1, 2, 3]);
-    final traceState = sdk.TraceState.fromString('test=onetwo');
+    final traceState = api.TraceState.fromString('test=onetwo');
     final testSpan = Span(
         'foo',
-        sdk.SpanContext.remote(
+        api.SpanContext.remote(
             traceId, api.SpanId([7, 8, 9]), api.TraceFlags.none, traceState),
         api.SpanId([4, 5, 6]),
         [],
@@ -105,10 +105,10 @@ void main() {
 
   test('with sampled, local sdk.Span', () {
     final traceId = api.TraceId([1, 2, 3]);
-    final traceState = sdk.TraceState.fromString('test=onetwo');
+    final traceState = api.TraceState.fromString('test=onetwo');
     final testSpan = Span(
         'foo',
-        sdk.SpanContext(
+        api.SpanContext(
             traceId, api.SpanId([7, 8, 9]), api.TraceFlags.sampled, traceState),
         api.SpanId([4, 5, 6]),
         [],
@@ -128,10 +128,10 @@ void main() {
 
   test('with non-sampled, local sdk.Span', () {
     final traceId = api.TraceId([1, 2, 3]);
-    final traceState = sdk.TraceState.fromString('test=onetwo');
+    final traceState = api.TraceState.fromString('test=onetwo');
     final testSpan = Span(
         'foo',
-        sdk.SpanContext(
+        api.SpanContext(
             traceId, api.SpanId([7, 8, 9]), api.TraceFlags.none, traceState),
         api.SpanId([4, 5, 6]),
         [],

--- a/test/unit/sdk/span_context_test.dart
+++ b/test/unit/sdk/span_context_test.dart
@@ -3,7 +3,6 @@
 
 @TestOn('vm')
 import 'package:opentelemetry/api.dart' as api;
-import 'package:opentelemetry/sdk.dart' as sdk;
 import 'package:test/test.dart';
 
 void main() {
@@ -11,10 +10,10 @@ void main() {
     final spanId = api.SpanId([4, 5, 6]);
     final traceId = api.TraceId([1, 2, 3]);
     const traceFlags = api.TraceFlags.none;
-    final traceState = sdk.TraceState.empty();
+    final traceState = api.TraceState.empty();
 
     final spanContext =
-        sdk.SpanContext(traceId, spanId, traceFlags, traceState);
+        api.SpanContext(traceId, spanId, traceFlags, traceState);
 
     expect(spanContext.traceId, same(traceId));
     expect(spanContext.spanId, same(spanId));

--- a/test/unit/sdk/span_limits_test.dart
+++ b/test/unit/sdk/span_limits_test.dart
@@ -3,7 +3,7 @@
 
 @TestOn('vm')
 
-import 'package:opentelemetry/api.dart';
+import 'package:opentelemetry/api.dart' as api;
 import 'package:opentelemetry/sdk.dart' as sdk;
 import 'package:test/test.dart';
 
@@ -12,32 +12,33 @@ void main() {
   const maxAttributeLength = 5;
   const maxLinks = 3;
   const maxAttributesPerLink = 3;
-  final attrShort = Attribute.fromString('shortkey', '55555');
-  final dupShort = Attribute.fromString('shortkey', '66666');
-  final attrLong = Attribute.fromString('longkey', '5555555');
-  final dupLong = Attribute.fromString('longkey', '666666666');
-  final dupShort2 = Attribute.fromString('shortkey', '77777');
-  final dupLong2 = Attribute.fromString('longkey', '77777777');
-  final attrInt = Attribute.fromInt('intKey', 12);
-  final attrBool = Attribute.fromBoolean('boolKey', true);
-  final attrDoubleArray = Attribute.fromDoubleList('doubleList', [0.1, 0.2]);
+  final attrShort = api.Attribute.fromString('shortkey', '55555');
+  final dupShort = api.Attribute.fromString('shortkey', '66666');
+  final attrLong = api.Attribute.fromString('longkey', '5555555');
+  final dupLong = api.Attribute.fromString('longkey', '666666666');
+  final dupShort2 = api.Attribute.fromString('shortkey', '77777');
+  final dupLong2 = api.Attribute.fromString('longkey', '77777777');
+  final attrInt = api.Attribute.fromInt('intKey', 12);
+  final attrBool = api.Attribute.fromBoolean('boolKey', true);
+  final attrDoubleArray =
+      api.Attribute.fromDoubleList('doubleList', [0.1, 0.2]);
   final attrStringArray =
-      Attribute.fromStringList('stringList', ['1111', '1111111']);
+      api.Attribute.fromStringList('stringList', ['1111', '1111111']);
   final limits = sdk.SpanLimits(
       maxNumAttributes: maxAttributes,
       maxNumAttributeLength: maxAttributeLength,
       maxNumLink: maxLinks,
       maxNumAttributesPerLink: maxAttributesPerLink);
-  final context = sdk.SpanContext(TraceId([1, 2, 3]), SpanId([7, 8, 9]),
-      TraceFlags.none, sdk.TraceState.empty());
-  final spanLink1 = SpanLink(context, attributes: [attrShort]);
-  final spanLink2 = SpanLink(context, attributes: [attrShort, attrLong]);
-  final spanLink3 =
-      SpanLink(context, attributes: [attrShort, dupShort, attrInt, attrBool]);
-  final spanLink4 = SpanLink(context, attributes: []);
-  final spanLinkStrs = SpanLink(context,
+  final context = api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+      api.TraceFlags.none, api.TraceState.empty());
+  final spanLink1 = api.SpanLink(context, attributes: [attrShort]);
+  final spanLink2 = api.SpanLink(context, attributes: [attrShort, attrLong]);
+  final spanLink3 = api.SpanLink(context,
+      attributes: [attrShort, dupShort, attrInt, attrBool]);
+  final spanLink4 = api.SpanLink(context, attributes: []);
+  final spanLinkStrs = api.SpanLink(context,
       attributes: [attrShort, attrLong, attrStringArray, dupShort]);
-  final spanLinkDup = SpanLink(context, attributes: [
+  final spanLinkDup = api.SpanLink(context, attributes: [
     attrShort,
     dupShort,
     attrLong,
@@ -45,10 +46,10 @@ void main() {
     dupShort2,
     dupLong2
   ]);
-  final spanLinkNoAttr = SpanLink(context);
+  final spanLinkNoAttr = api.SpanLink(context);
 
   test('test default spanLimits', () {
-    final span = sdk.Span('limitTest', null, SpanId([4, 5, 6]), [],
+    final span = sdk.Span('limitTest', null, api.SpanId([4, 5, 6]), [],
         sdk.DateTimeTimeProvider(), null, null,
         attributes: [attrShort, attrDoubleArray, attrStringArray],
         limits: sdk.SpanLimits());
@@ -60,7 +61,7 @@ void main() {
   });
 
   test('test spanLimits maxNumAttributes', () {
-    final span = sdk.Span('foo', null, SpanId([4, 5, 6]), [],
+    final span = sdk.Span('foo', null, api.SpanId([4, 5, 6]), [],
         sdk.DateTimeTimeProvider(), null, null,
         attributes: [attrShort, attrLong, attrInt, attrBool], limits: limits);
     expect(span.attributes.length, equals(maxAttributes));
@@ -68,7 +69,7 @@ void main() {
   });
 
   test('test spanLimits maxNumAttributeLength', () {
-    final span = sdk.Span('foo', null, SpanId([4, 5, 6]), [],
+    final span = sdk.Span('foo', null, api.SpanId([4, 5, 6]), [],
         sdk.DateTimeTimeProvider(), null, null,
         attributes: [attrShort, attrLong], limits: limits);
     expect(span.attributes.get('shortkey'),

--- a/test/unit/sdk/span_test.dart
+++ b/test/unit/sdk/span_test.dart
@@ -10,8 +10,8 @@ void main() {
   test('span change name', () {
     final span = sdk.Span(
         'foo',
-        sdk.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, sdk.TraceState.empty()),
+        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+            api.TraceFlags.none, api.TraceState.empty()),
         api.SpanId([4, 5, 6]),
         [],
         sdk.DateTimeTimeProvider(),

--- a/test/unit/sdk/trace_state_test.dart
+++ b/test/unit/sdk/trace_state_test.dart
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
 @TestOn('vm')
-import 'package:opentelemetry/src/sdk/trace/trace_state.dart';
+import 'package:opentelemetry/sdk.dart' as sdk;
 import 'package:test/test.dart';
 
 void main() {
   test('create empty', () {
-    final testTraceState = TraceState.empty();
+    final testTraceState = sdk.TraceState.empty();
 
     expect(testTraceState.toString(), equals(''));
     expect(testTraceState.isEmpty, isTrue);
@@ -15,7 +15,8 @@ void main() {
   });
 
   test('create from string', () {
-    final testTraceState = TraceState.fromString('key1=value2,key@2=value1');
+    final testTraceState =
+        sdk.TraceState.fromString('key1=value2,key@2=value1');
 
     expect(testTraceState.get('key1'), equals('value2')); // Regular key.
     expect(testTraceState.get('key@2'), equals('value1')); // Vendor key.
@@ -25,7 +26,7 @@ void main() {
   });
 
   test('get default', () {
-    final testTraceState = TraceState.getDefault();
+    final testTraceState = sdk.TraceState.getDefault();
 
     expect(testTraceState.toString(), equals(''));
     expect(testTraceState.isEmpty, isTrue);
@@ -33,7 +34,7 @@ void main() {
   });
 
   test('put valid values', () {
-    final testTraceState = TraceState.empty()
+    final testTraceState = sdk.TraceState.empty()
       ..put('key_0-1', 'value@2')
       ..put('key_0-2', 'value@1')
       ..put('key_@vendor', 'value@3');
@@ -48,7 +49,7 @@ void main() {
   });
 
   test('create from string with invalid values', () {
-    final testTraceState = TraceState.fromString(
+    final testTraceState = sdk.TraceState.fromString(
         'key_0-1=0,value2,key&0-2=value@1,key_@thisisalotlongerthan13characters=value@3');
 
     expect(testTraceState.get('key_0-1'), isNull); // Invalid value, comma.
@@ -61,7 +62,7 @@ void main() {
   });
 
   test('put invalid values', () {
-    final testTraceState = TraceState.empty()
+    final testTraceState = sdk.TraceState.empty()
       ..put('key_0-1', '0,value=2') // Invalid value.
       ..put('key&0-2', 'value@1') // Invalid key.
       ..put('key_@thisisalotlongerthan13characters',
@@ -76,7 +77,7 @@ void main() {
   });
 
   test('remove valid value', () {
-    final testTraceState = TraceState.empty()
+    final testTraceState = sdk.TraceState.empty()
       ..put('key_0-1', 'value@2')
       ..put('key_0-2', 'value@1')
       ..put('key_@vendor', 'value@3')
@@ -92,41 +93,43 @@ void main() {
   });
 
   test('key regex, valid key', () {
-    final matchResult = TraceState.validKeyRegex.matchAsPrefix('key_0-1');
+    final matchResult = sdk.TraceState.validKeyRegex.matchAsPrefix('key_0-1');
 
     expect(matchResult, isNotNull);
     expect(matchResult.group(0), equals('key_0-1'));
   });
 
   test('key regex, valid vendor key', () {
-    final matchResult = TraceState.validKeyRegex.matchAsPrefix('key_@vendor');
+    final matchResult =
+        sdk.TraceState.validKeyRegex.matchAsPrefix('key_@vendor');
 
     expect(matchResult, isNotNull);
     expect(matchResult.group(0), equals('key_@vendor'));
   });
 
   test('value regex, valid value', () {
-    final matchResult = TraceState.validValueRegex.matchAsPrefix('value@2');
+    final matchResult = sdk.TraceState.validValueRegex.matchAsPrefix('value@2');
 
     expect(matchResult, isNotNull);
     expect(matchResult.group(0), equals('value@2'));
   });
 
   test('key regex, invalid key', () {
-    final matchResult = TraceState.validKeyRegex.matchAsPrefix('key&0-2');
+    final matchResult = sdk.TraceState.validKeyRegex.matchAsPrefix('key&0-2');
 
     expect(matchResult, isNull);
   });
 
   test('key regex, invalid vendor key', () {
-    final matchResult = TraceState.validKeyRegex
+    final matchResult = sdk.TraceState.validKeyRegex
         .matchAsPrefix('key_@thisisalotlongerthan13characters');
 
     expect(matchResult, isNull);
   });
 
   test('value regex, invalid value', () {
-    final matchResult = TraceState.validValueRegex.matchAsPrefix('0,value=2');
+    final matchResult =
+        sdk.TraceState.validValueRegex.matchAsPrefix('0,value=2');
 
     expect(matchResult, isNull);
   });


### PR DESCRIPTION
## Which problem is this PR solving?

This library does not closely adhere to the OpenTelemetry Specification.  To improve adherence to the specification and lay the ground-work for null-safety, this PR makes the following changes:

* Fields in `TracerProviderBase` are now protected rather than private.  
* `WebTracerProvider` now uses fields on its super class, where possible.
* Constructor for `SpanLimits` is now constant.
* Added `NoopTextMapPropagator`, which `globalTextMapPropagator` now uses by default.
* Added `NoopTracerProvider`, which `globalTracerProvider` now uses by default.
* Began the process of migrating `Span.setStatus` to `Span.setStatusCode`.  The latter includes an updated function signature which uses positional optional arguments instead of named optional arguments.
* Added deprecation messages for planned future breaking changes.
* Updated references to SDK `SpanContext` and `TraceState` in unrelated unit tests.  These classes were moved to API in #109 and should no longer be used.

## How Has This Been Tested?

* Confirmed passing unit tests
* Updated a test application from a previous version.  Confirmed that changes are non-breaking with no further updates.
