### PR TITLE
O11Y-1786: Implement Read-Only Spans

### DIFF
--- a/lib/sdk.dart
+++ b/lib/sdk.dart
@@ -6,6 +6,7 @@ export 'src/sdk/resource/resource.dart' show Resource;
 export 'src/sdk/time_providers/datetime_time_provider.dart'
     show DateTimeTimeProvider;
 export 'src/sdk/time_providers/time_provider.dart' show TimeProvider;
+export 'src/sdk/trace/exporters/span_exporter.dart' show SpanExporter;
 export 'src/sdk/trace/exporters/collector_exporter.dart' show CollectorExporter;
 export 'src/sdk/trace/exporters/console_exporter.dart' show ConsoleExporter;
 export 'src/sdk/trace/id_generator.dart' show IdGenerator;
@@ -16,7 +17,10 @@ export 'src/sdk/trace/sampling/parent_based_sampler.dart'
 export 'src/sdk/trace/sampling/sampler.dart' show Sampler;
 export 'src/sdk/trace/sampling/sampling_result.dart'
     show Decision, SamplingResult;
+export 'src/sdk/trace/read_only_span.dart' show ReadOnlySpan;
+export 'src/sdk/trace/read_write_span.dart' show ReadWriteSpan;
 export 'src/sdk/trace/span_limits.dart' show SpanLimits;
+export 'src/sdk/trace/span_processors/span_processor.dart' show SpanProcessor;
 export 'src/sdk/trace/span_processors/batch_processor.dart'
     show BatchSpanProcessor;
 export 'src/sdk/trace/span_processors/simple_processor.dart'

--- a/lib/src/api/trace/nonrecording_span.dart
+++ b/lib/src/api/trace/nonrecording_span.dart
@@ -15,7 +15,7 @@ import '../../../api.dart' as api;
 @Deprecated(
     'This class will stop being exported in v0.17.0.  Please use [api.Span] instead.')
 class NonRecordingSpan implements api.Span {
-  final api.SpanStatus _status = api.SpanStatus()..code = api.StatusCode.ok;
+  final api.SpanId _parentSpanId = api.SpanId.invalid();
   final api.SpanContext _spanContext;
 
   NonRecordingSpan(this._spanContext);
@@ -30,19 +30,10 @@ class NonRecordingSpan implements api.Span {
   void end() {}
 
   @override
-  Int64 get endTime => null;
+  void setName(String _name) {}
 
   @override
-  String get name => 'NON_RECORDING';
-
-  @override
-  set name(String _name) {}
-
-  @override
-  bool get isRecording => false;
-
-  @override
-  api.SpanId get parentSpanId => api.SpanId.invalid();
+  api.SpanId get parentSpanId => _parentSpanId;
 
   @override
   @Deprecated(
@@ -53,21 +44,9 @@ class NonRecordingSpan implements api.Span {
   api.SpanContext get spanContext => _spanContext;
 
   @override
-  Int64 get startTime => null;
-
-  @override
-  api.SpanStatus get status => _status;
-
-  @override
-  api.InstrumentationLibrary get instrumentationLibrary => null;
-
-  @override
   void recordException(dynamic exception, {StackTrace stackTrace}) {}
 
   @override
   void addEvent(String name, Int64 timestamp,
       {List<api.Attribute> attributes}) {}
-
-  @override
-  api.SpanKind get kind => api.SpanKind.internal;
 }

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -38,24 +38,11 @@ abstract class Span {
   /// span ends.
   api.SpanContext get spanContext;
 
-  /// Get the time when the span was closed, or null if still open.
-  Int64 get endTime;
-
-  /// Get the time when the span was started.
-  Int64 get startTime;
-
   /// The parent span id.
   api.SpanId get parentSpanId;
 
-  /// The name of the span.
-  String name;
-
-  /// Whether this Span is recording information like events with the
-  /// addEvent operation, status with setStatus, etc.
-  bool get isRecording;
-
-  /// The kind of the span.
-  SpanKind get kind;
+  /// Sets the name of the [Span].
+  void setName(String name);
 
   /// Sets the status to the [Span].
   ///
@@ -68,17 +55,11 @@ abstract class Span {
       'This method will be updated to use positional optional parameters in v0.17.0.')
   void setStatus(api.StatusCode status, {String description});
 
-  /// Retrieve the status of the [Span].
-  api.SpanStatus get status;
-
   /// set single attribute
   void setAttribute(api.Attribute attribute);
 
   /// set multiple attributes
   void setAttributes(List<api.Attribute> attributes);
-
-  /// Retrieve the instrumentation library on this span.
-  api.InstrumentationLibrary get instrumentationLibrary;
 
   /// Record metadata about an event occurring during this span.
   void addEvent(String name, Int64 timestamp, {List<api.Attribute> attributes});

--- a/lib/src/sdk/platforms/web/trace/web_tracer_provider.dart
+++ b/lib/src/sdk/platforms/web/trace/web_tracer_provider.dart
@@ -36,7 +36,7 @@ class WebTracerProvider extends sdk.TracerProviderBase {
             spanLimits: spanLimits ?? sdk.SpanLimits());
 
   @override
-  Tracer getTracer(String name, {String version = ''}) {
+  api.Tracer getTracer(String name, {String version = ''}) {
     return tracers.putIfAbsent(
         '$name@$version',
         () => Tracer(processors, resource, sampler, _timeProvider, idGenerator,

--- a/lib/src/sdk/platforms/web/trace/web_tracer_provider.dart
+++ b/lib/src/sdk/platforms/web/trace/web_tracer_provider.dart
@@ -19,7 +19,7 @@ class WebTracerProvider extends sdk.TracerProviderBase {
   final sdk.TimeProvider _timeProvider;
 
   WebTracerProvider(
-      {List<api.SpanProcessor> processors,
+      {List<sdk.SpanProcessor> processors,
       sdk.Resource resource,
       sdk.Sampler sampler,
       sdk.TimeProvider timeProvider,
@@ -36,7 +36,7 @@ class WebTracerProvider extends sdk.TracerProviderBase {
             spanLimits: spanLimits ?? sdk.SpanLimits());
 
   @override
-  api.Tracer getTracer(String name, {String version = ''}) {
+  Tracer getTracer(String name, {String version = ''}) {
     return tracers.putIfAbsent(
         '$name@$version',
         () => Tracer(processors, resource, sampler, _timeProvider, idGenerator,

--- a/lib/src/sdk/trace/exporters/console_exporter.dart
+++ b/lib/src/sdk/trace/exporters/console_exporter.dart
@@ -1,14 +1,12 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import '../../../api/trace/span.dart';
+import '../../../../sdk.dart' as sdk;
 
-import '../../../api/exporters/span_exporter.dart';
-
-class ConsoleExporter implements SpanExporter {
+class ConsoleExporter implements sdk.SpanExporter {
   var _isShutdown = false;
 
-  void _printSpans(List<Span> spans) {
+  void _printSpans(List<sdk.ReadOnlySpan> spans) {
     for (var i = 0; i < spans.length; i++) {
       final span = spans[i];
       print({
@@ -27,7 +25,7 @@ class ConsoleExporter implements SpanExporter {
   }
 
   @override
-  void export(List<Span> spans) {
+  void export(List<sdk.ReadOnlySpan> spans) {
     if (_isShutdown) {
       return;
     }

--- a/lib/src/sdk/trace/exporters/span_exporter.dart
+++ b/lib/src/sdk/trace/exporters/span_exporter.dart
@@ -1,12 +1,10 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import '../../../api.dart' as api;
+import '../../../../sdk.dart' as sdk;
 
-@Deprecated(
-    'This class will be moved to the SDK package in v0.18.0.  Use [SpanExporter] from SDK instead.')
 abstract class SpanExporter {
-  void export(List<api.Span> spans);
+  void export(List<sdk.ReadOnlySpan> spans);
 
   void forceFlush();
 

--- a/lib/src/sdk/trace/read_only_span.dart
+++ b/lib/src/sdk/trace/read_only_span.dart
@@ -1,0 +1,50 @@
+// Copyright 2021-2022 Workiva.
+// Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
+
+import 'package:fixnum/fixnum.dart';
+
+import '../../sdk/common/attributes.dart';
+import '../../../api.dart' as api;
+import '../../../sdk.dart' as sdk;
+
+/// A representation of the readable portions of a single operation
+/// within a trace.
+///
+/// Warning: methods may be added to this interface in minor releases.
+abstract class ReadOnlySpan {
+  /// The name of the span.
+  String get name;
+
+  /// The kind of the span.
+  api.SpanKind get kind;
+
+  /// The context associated with this span.
+  ///
+  /// This context is an immutable, serializable identifier for this span that
+  /// can be used to create new child spans and remains usable even after this
+  /// span ends.
+  api.SpanContext get spanContext;
+
+  /// The parent span id.
+  api.SpanId get parentSpanId;
+
+  /// The time when the span was started.
+  Int64 get startTime;
+
+  /// The time when the span was closed, or null if still open.
+  Int64 get endTime;
+
+  /// The status of the span.
+  api.SpanStatus get status;
+
+  // TODO: O11Y-1531: SpanEvents here.
+
+  /// The instrumentation library for the span.
+  api.InstrumentationLibrary get instrumentationLibrary;
+
+  List<api.SpanLink> get links;
+
+  Attributes get attributes;
+
+  sdk.Resource get resource;
+}

--- a/lib/src/sdk/trace/read_write_span.dart
+++ b/lib/src/sdk/trace/read_write_span.dart
@@ -1,0 +1,7 @@
+// Copyright 2021-2022 Workiva.
+// Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
+
+import 'package:opentelemetry/api.dart' as api;
+import 'package:opentelemetry/sdk.dart' as sdk;
+
+abstract class ReadWriteSpan implements sdk.ReadOnlySpan, api.Span {}

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -10,12 +10,12 @@ import '../common/attributes.dart';
 /// A representation of a single operation within a trace.
 @Deprecated(
     'This class will stop being exported and be marked protected in v0.17.0.  Consumers should use [api.Span] instead.')
-class Span implements api.Span {
+class Span implements sdk.ReadWriteSpan {
   final api.SpanContext _spanContext;
   final api.SpanId _parentSpanId;
   final api.SpanKind _kind;
   final api.SpanStatus _status = api.SpanStatus();
-  final List<api.SpanProcessor> _processors;
+  final List<sdk.SpanProcessor> _processors;
   final List<api.SpanLink> _links;
   final sdk.TimeProvider _timeProvider;
   final sdk.Resource _resource;
@@ -23,19 +23,24 @@ class Span implements api.Span {
   final api.InstrumentationLibrary _instrumentationLibrary;
   final Int64 _startTime;
   final Attributes _attributes = Attributes.empty();
+  String _name;
   Int64 _endTime;
   int _droppedSpanAttributes = 0;
 
   @override
-  String name;
+  void setName(String name) {
+    _name = name;
+  }
 
   @override
+  String get name => _name;
+
   bool get isRecording => _endTime == null;
 
   /// Construct a [Span].
   @Deprecated(
       'This constructor will be marked protected in v0.17.0.  Consumers should use [api.Span] instead.')
-  Span(this.name, this._spanContext, this._parentSpanId, this._processors,
+  Span(this._name, this._spanContext, this._parentSpanId, this._processors,
       this._timeProvider, this._resource, this._instrumentationLibrary,
       {api.SpanKind kind,
       List<api.Attribute> attributes,
@@ -98,6 +103,7 @@ class Span implements api.Span {
   @override
   api.SpanStatus get status => _status;
 
+  @override
   sdk.Resource get resource => _resource;
 
   @override
@@ -223,8 +229,10 @@ class Span implements api.Span {
     return spanLink;
   }
 
-  List<api.SpanLink> get links => _links;
+  @override
+  List<api.SpanLink> get links => List.unmodifiable(_links);
 
+  @override
   Attributes get attributes => _attributes;
 
   //Truncate just strings which length is longer than configuration.

--- a/lib/src/sdk/trace/span_processors/batch_processor.dart
+++ b/lib/src/sdk/trace/span_processors/batch_processor.dart
@@ -7,13 +7,14 @@ import 'dart:math';
 import 'package:logging/logging.dart';
 
 import '../../../../api.dart' as api;
+import '../../../../sdk.dart' as sdk;
 
-class BatchSpanProcessor implements api.SpanProcessor {
+class BatchSpanProcessor implements sdk.SpanProcessor {
   final _log = Logger('opentelemetry.BatchSpanProcessor');
 
-  final api.SpanExporter _exporter;
+  final sdk.SpanExporter _exporter;
   bool _isShutdown = false;
-  final List<api.Span> _spanBuffer = [];
+  final List<sdk.ReadOnlySpan> _spanBuffer = [];
   Timer _timer;
 
   int _maxExportBatchSize = 512;
@@ -42,7 +43,7 @@ class BatchSpanProcessor implements api.SpanProcessor {
   }
 
   @override
-  void onEnd(api.Span span) {
+  void onEnd(sdk.ReadOnlySpan span) {
     if (_isShutdown) {
       return;
     }
@@ -50,7 +51,7 @@ class BatchSpanProcessor implements api.SpanProcessor {
   }
 
   @override
-  void onStart(api.Span span, api.Context parentContext) {}
+  void onStart(sdk.ReadWriteSpan span, api.Context parentContext) {}
 
   @override
   void shutdown() {
@@ -60,7 +61,7 @@ class BatchSpanProcessor implements api.SpanProcessor {
     _exporter.shutdown();
   }
 
-  void _addToBuffer(api.Span span) {
+  void _addToBuffer(sdk.ReadOnlySpan span) {
     if (_spanBuffer.length >= _maxQueueSize) {
       // Buffer is full, drop span.
       _log.warning(

--- a/lib/src/sdk/trace/span_processors/simple_processor.dart
+++ b/lib/src/sdk/trace/span_processors/simple_processor.dart
@@ -2,9 +2,10 @@
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
 import '../../../../api.dart' as api;
+import '../../../../sdk.dart' as sdk;
 
-class SimpleSpanProcessor implements api.SpanProcessor {
-  final api.SpanExporter _exporter;
+class SimpleSpanProcessor implements sdk.SpanProcessor {
+  final sdk.SpanExporter _exporter;
   bool _isShutdown = false;
 
   SimpleSpanProcessor(this._exporter);
@@ -15,7 +16,7 @@ class SimpleSpanProcessor implements api.SpanProcessor {
   }
 
   @override
-  void onEnd(api.Span span) {
+  void onEnd(sdk.ReadOnlySpan span) {
     if (_isShutdown) {
       return;
     }
@@ -24,7 +25,7 @@ class SimpleSpanProcessor implements api.SpanProcessor {
   }
 
   @override
-  void onStart(api.Span span, api.Context parentContext) {}
+  void onStart(sdk.ReadWriteSpan span, api.Context parentContext) {}
 
   @override
   void shutdown() {

--- a/lib/src/sdk/trace/span_processors/span_processor.dart
+++ b/lib/src/sdk/trace/span_processors/span_processor.dart
@@ -1,14 +1,13 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import '../../../api.dart' as api;
+import '../../../../api.dart' as api;
+import '../../../../sdk.dart' as sdk;
 
-@Deprecated(
-    'This class will be moved to the SDK package in v0.18.0.  Use [SpanExporter] from SDK instead.')
 abstract class SpanProcessor {
-  void onStart(api.Span span, api.Context parentContext);
+  void onStart(sdk.ReadWriteSpan span, api.Context parentContext);
 
-  void onEnd(api.Span span);
+  void onEnd(sdk.ReadOnlySpan span);
 
   void shutdown();
 

--- a/lib/src/sdk/trace/tracer.dart
+++ b/lib/src/sdk/trace/tracer.dart
@@ -9,7 +9,7 @@ import 'span.dart';
 
 /// An interface for creating [api.Span]s and propagating context in-process.
 class Tracer implements api.Tracer {
-  final List<api.SpanProcessor> _processors;
+  final List<sdk.SpanProcessor> _processors;
   final sdk.Resource _resource;
   final sdk.Sampler _sampler;
   final sdk.TimeProvider _timeProvider;
@@ -25,7 +25,7 @@ class Tracer implements api.Tracer {
       : _spanLimits = spanLimits ?? sdk.SpanLimits();
 
   @override
-  api.Span startSpan(String name,
+  Span startSpan(String name,
       {api.Context context,
       api.SpanKind kind,
       List<api.Attribute> attributes,
@@ -37,16 +37,15 @@ class Tracer implements api.Tracer {
     // parent.  If the Context does not contain an active parent Span, create
     // a root Span with a new Trace ID and default state.
     // See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#determining-the-parent-span-from-a-context
-    final parent = context.span;
     final spanId = api.SpanId.fromIdGenerator(_idGenerator);
     api.TraceId traceId;
     api.TraceState traceState;
     api.SpanId parentSpanId;
 
-    if (parent != null) {
-      parentSpanId = parent.spanContext.spanId;
-      traceId = parent.spanContext.traceId;
-      traceState = parent.spanContext.traceState;
+    if (context.span != null) {
+      parentSpanId = context.spanContext.spanId;
+      traceId = context.spanContext.traceId;
+      traceState = context.spanContext.traceState;
     } else {
       parentSpanId = api.SpanId.root();
       traceId = api.TraceId.fromIdGenerator(_idGenerator);

--- a/lib/src/sdk/trace/tracer.dart
+++ b/lib/src/sdk/trace/tracer.dart
@@ -25,7 +25,7 @@ class Tracer implements api.Tracer {
       : _spanLimits = spanLimits ?? sdk.SpanLimits();
 
   @override
-  Span startSpan(String name,
+  api.Span startSpan(String name,
       {api.Context context,
       api.SpanKind kind,
       List<api.Attribute> attributes,

--- a/lib/src/sdk/trace/tracer_provider.dart
+++ b/lib/src/sdk/trace/tracer_provider.dart
@@ -42,7 +42,7 @@ class TracerProviderBase implements api.TracerProvider {
   List<sdk.SpanProcessor> get spanProcessors => processors;
 
   @override
-  Tracer getTracer(String name, {String version = ''}) {
+  api.Tracer getTracer(String name, {String version = ''}) {
     final key = '$name@$version';
     return tracers.putIfAbsent(
         key,

--- a/lib/src/sdk/trace/tracer_provider.dart
+++ b/lib/src/sdk/trace/tracer_provider.dart
@@ -10,10 +10,10 @@ import '../../../sdk.dart' as sdk;
 /// A registry for creating named [api.Tracer]s.
 class TracerProviderBase implements api.TracerProvider {
   @protected
-  final Map<String, api.Tracer> tracers = {};
+  final Map<String, Tracer> tracers = {};
 
   @protected
-  final List<api.SpanProcessor> processors;
+  final List<sdk.SpanProcessor> processors;
 
   @protected
   final sdk.Resource resource;
@@ -28,7 +28,7 @@ class TracerProviderBase implements api.TracerProvider {
   final sdk.SpanLimits spanLimits;
 
   TracerProviderBase(
-      {List<api.SpanProcessor> processors,
+      {List<sdk.SpanProcessor> processors,
       sdk.Resource resource,
       sdk.Sampler sampler,
       api.IdGenerator idGenerator,
@@ -39,10 +39,10 @@ class TracerProviderBase implements api.TracerProvider {
         idGenerator = idGenerator ?? sdk.IdGenerator(),
         spanLimits = spanLimits ?? sdk.SpanLimits();
 
-  List<api.SpanProcessor> get spanProcessors => processors;
+  List<sdk.SpanProcessor> get spanProcessors => processors;
 
   @override
-  api.Tracer getTracer(String name, {String version = ''}) {
+  Tracer getTracer(String name, {String version = ''}) {
     final key = '$name@$version';
     return tracers.putIfAbsent(
         key,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 dev_dependencies:
   mockito: ^5.3.2
   remove_from_coverage: ^2.0.0
-  test: ^1.21.1
+  test: ^1.24.2
   workiva_analysis_options: ^1.2.2
 
 dependency_validator:

--- a/test/integration/api/propagation/w3c_trace_context_propagator_test.dart
+++ b/test/integration/api/propagation/w3c_trace_context_propagator_test.dart
@@ -4,6 +4,7 @@
 @TestOn('vm')
 import 'package:opentelemetry/api.dart' as api;
 import 'package:opentelemetry/sdk.dart' as sdk;
+import 'package:opentelemetry/src/api/trace/nonrecording_span.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:test/test.dart';
 
@@ -125,7 +126,7 @@ void main() {
         .span;
 
     // Use the transmitted Span as a receiver.
-    api.Span resultSpan;
+    Span resultSpan;
     api.Context.current.withSpan(parentSpan).execute(() {
       resultSpan = tracer.startSpan('doWork')..end();
     });

--- a/test/integration/sdk/tracer_test.dart
+++ b/test/integration/sdk/tracer_test.dart
@@ -4,6 +4,7 @@
 @TestOn('vm')
 import 'package:opentelemetry/api.dart' as api;
 import 'package:opentelemetry/sdk.dart' as sdk;
+import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/tracer.dart';
 import 'package:test/test.dart';
 

--- a/test/integration/sdk/tracer_test.dart
+++ b/test/integration/sdk/tracer_test.dart
@@ -17,7 +17,7 @@ void main() {
         sdk.IdGenerator(),
         sdk.InstrumentationLibrary('name', 'version'));
 
-    final span = tracer.startSpan('foo');
+    final span = tracer.startSpan('foo') as Span;
 
     expect(span.startTime, isNotNull);
     expect(span.endTime, isNull);
@@ -36,7 +36,7 @@ void main() {
     final parentSpan = tracer.startSpan('foo');
     final context = api.Context.current.withSpan(parentSpan);
 
-    final childSpan = tracer.startSpan('bar', context: context);
+    final childSpan = tracer.startSpan('bar', context: context) as Span;
 
     expect(childSpan.startTime, isNotNull);
     expect(childSpan.endTime, isNull);

--- a/test/unit/api/propagation/w3c_trace_context_propagator_test.dart
+++ b/test/unit/api/propagation/w3c_trace_context_propagator_test.dart
@@ -4,6 +4,7 @@
 @TestOn('vm')
 import 'package:opentelemetry/api.dart' as api;
 import 'package:opentelemetry/sdk.dart' as sdk;
+import 'package:opentelemetry/src/api/trace/nonrecording_span.dart';
 import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
 import 'package:opentelemetry/src/sdk/resource/resource.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';

--- a/test/unit/mocks.dart
+++ b/test/unit/mocks.dart
@@ -4,15 +4,18 @@
 import 'package:http/http.dart' as http;
 import 'package:mockito/mockito.dart';
 import 'package:opentelemetry/src/api/context/context.dart';
-import 'package:opentelemetry/src/api/exporters/span_exporter.dart';
-import 'package:opentelemetry/src/api/span_processors/span_processor.dart';
-import 'package:opentelemetry/src/api/trace/span.dart';
+import 'package:opentelemetry/src/sdk/trace/exporters/span_exporter.dart';
+import 'package:opentelemetry/src/sdk/trace/read_only_span.dart';
+import 'package:opentelemetry/src/sdk/trace/span_processors/span_processor.dart';
+import 'package:opentelemetry/src/sdk/trace/span.dart';
 
 class MockContext extends Mock implements Context {}
 
 class MockHTTPClient extends Mock implements http.Client {}
 
 class MockSpan extends Mock implements Span {}
+
+class MockReadOnlySpan extends Mock implements ReadOnlySpan {}
 
 class MockSpanExporter extends Mock implements SpanExporter {}
 

--- a/test/unit/sdk/platforms/web/web_trace_provider_test.dart
+++ b/test/unit/sdk/platforms/web/web_trace_provider_test.dart
@@ -59,7 +59,7 @@ void main() {
 
   test('browserTracerProvider creates a tracer which can create valid spans',
       () async {
-    final span = WebTracerProvider(processors: [MockSpanProcessor()])
+    final Span span = WebTracerProvider(processors: [MockSpanProcessor()])
         .getTracer('testTracer')
         .startSpan('testSpan', context: Context.root)
       ..end();

--- a/test/unit/sdk/platforms/web/web_trace_provider_test.dart
+++ b/test/unit/sdk/platforms/web/web_trace_provider_test.dart
@@ -4,7 +4,8 @@
 @TestOn('chrome')
 import 'package:mockito/mockito.dart';
 import 'package:opentelemetry/src/api/context/context.dart';
-import 'package:opentelemetry/src/api/span_processors/span_processor.dart';
+import 'package:opentelemetry/src/sdk/trace/span.dart';
+import 'package:opentelemetry/src/sdk/trace/span_processors/span_processor.dart';
 import 'package:opentelemetry/src/sdk/platforms/web/trace/web_tracer_provider.dart';
 import 'package:test/test.dart';
 

--- a/test/unit/sdk/span_processors/batch_processor_test.dart
+++ b/test/unit/sdk/span_processors/batch_processor_test.dart
@@ -3,7 +3,8 @@
 
 @TestOn('vm')
 import 'package:mockito/mockito.dart';
-import 'package:opentelemetry/src/api/exporters/span_exporter.dart';
+import 'package:opentelemetry/src/sdk/trace/exporters/span_exporter.dart';
+import 'package:opentelemetry/src/sdk/trace/read_only_span.dart';
 import 'package:opentelemetry/src/api/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_processors/batch_processor.dart';
 import 'package:test/test.dart';
@@ -13,12 +14,12 @@ import '../../mocks.dart';
 void main() {
   BatchSpanProcessor processor;
   SpanExporter mockExporter;
-  Span mockSpan1, mockSpan2, mockSpan3;
+  ReadOnlySpan mockSpan1, mockSpan2, mockSpan3;
 
   setUp(() {
-    mockSpan1 = MockSpan();
-    mockSpan2 = MockSpan();
-    mockSpan3 = MockSpan();
+    mockSpan1 = MockReadOnlySpan();
+    mockSpan2 = MockReadOnlySpan();
+    mockSpan3 = MockReadOnlySpan();
 
     mockExporter = MockSpanExporter();
     processor = BatchSpanProcessor(mockExporter,

--- a/test/unit/sdk/span_processors/simple_processor_test.dart
+++ b/test/unit/sdk/span_processors/simple_processor_test.dart
@@ -3,8 +3,9 @@
 
 @TestOn('vm')
 import 'package:mockito/mockito.dart';
-import 'package:opentelemetry/src/api/exporters/span_exporter.dart';
-import 'package:opentelemetry/src/api/trace/span.dart';
+import 'package:opentelemetry/src/sdk/trace/exporters/span_exporter.dart';
+import 'package:opentelemetry/src/sdk/trace/read_only_span.dart';
+import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_processors/simple_processor.dart';
 import 'package:test/test.dart';
 

--- a/test/unit/sdk/span_test.dart
+++ b/test/unit/sdk/span_test.dart
@@ -19,7 +19,7 @@ void main() {
         sdk.InstrumentationLibrary('library_name', 'library_version'));
     expect(span.name, equals('foo'));
 
-    span.name = 'bar';
+    span.setName('bar');
     expect(span.name, equals('bar'));
     expect(span.resource.attributes.get('service-name'), equals('foo'));
   });

--- a/test/unit/sdk/trace_provider_test.dart
+++ b/test/unit/sdk/trace_provider_test.dart
@@ -3,7 +3,7 @@
 
 @TestOn('vm')
 import 'package:mockito/mockito.dart';
-import 'package:opentelemetry/src/api/span_processors/span_processor.dart';
+import 'package:opentelemetry/src/sdk/trace/span_processors/span_processor.dart';
 import 'package:opentelemetry/src/sdk/trace/tracer_provider.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
## Which problem is this PR solving?

This PR implements read-only Spans in order to prevent modification during processing and export.

* API:  Added `ReadableSpan`, which contains the read-able portions formerly contained in `Span`.
* API:  `Span` now extends `ReadableSpan` and adds write-able portions.
* SDK:  Added `ReadableSpan` which extends API's `ReadableSpan` to add readable, non-consumer-facing properties like links and attributes.
* SDK:  `Span` now implements API's `Span` and SDK's `ReadableSpan`.
* SDK:  Processors and Exporters now expect `ReadableSpan`s.

## How Has This Been Tested?

* Confirmed passing unit tests
* Updated a test application from a previous version. Confirmed that changes operate properly with no further updates.
