### PR TITLE
O11Y-3603: Deprecate InstrumentationLibrary for InstrumentationScope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18.7
+FROM dart:2.19.6
 WORKDIR /build
 
 RUN apt update && apt install -y make protobuf-compiler gnupg wget

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 init:
 	git submodule init
+	# Pull opentelemetry-proto at the stored commit.
+	# To upgrade, execute `git submodule update --remote --merge`
+	# and commit the result.
 	git submodule update
 	dart pub get
 	dart pub global activate protoc_plugin 21.1.2

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ init:
 	git submodule init
 	git submodule update
 	dart pub get
-	dart pub global activate protoc_plugin 20.0.1
+	dart pub global activate protoc_plugin 21.1.2
 	cd lib/src/sdk/proto && \
 		protoc --proto_path opentelemetry-proto --dart_out . \
 			opentelemetry-proto/opentelemetry/proto/common/v1/common.proto \

--- a/lib/sdk.dart
+++ b/lib/sdk.dart
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
 export 'src/sdk/instrumentation_library.dart' show InstrumentationLibrary;
+export 'src/sdk/common/instrumentation_scope.dart' show InstrumentationScope;
 export 'src/sdk/resource/resource.dart' show Resource;
 export 'src/sdk/time_providers/datetime_time_provider.dart'
     show DateTimeTimeProvider;

--- a/lib/src/api/instrumentation_library.dart
+++ b/lib/src/api/instrumentation_library.dart
@@ -4,6 +4,7 @@
 /// Represents versioning metadata for this library within applications
 /// which use multiple implementations of OpenTelemetry.
 // See https://github.com/open-telemetry/oteps/blob/main/text/0083-component.md#instrumentationlibrary
+@Deprecated('This class will be removed in 0.18.0.')
 abstract class InstrumentationLibrary {
   String get name;
   String get version;

--- a/lib/src/api/trace/noop_tracer_provider.dart
+++ b/lib/src/api/trace/noop_tracer_provider.dart
@@ -9,7 +9,8 @@ class NoopTracerProvider implements api.TracerProvider {
   void forceFlush() {}
 
   @override
-  api.Tracer getTracer(String name, {String version}) {
+  api.Tracer getTracer(String name,
+      {String version, String schemaUrl, List<api.Attribute> attributes}) {
     return NoopTracer();
   }
 

--- a/lib/src/api/trace/tracer_provider.dart
+++ b/lib/src/api/trace/tracer_provider.dart
@@ -12,7 +12,8 @@ abstract class TracerProvider {
   ///
   /// [name] should be the name of the tracer or instrumentation library.
   /// [version] should be the version of the tracer or instrumentation library.
-  api.Tracer getTracer(String name, {String version});
+  api.Tracer getTracer(String name,
+      {String version, String schemaUrl, List<api.Attribute> attributes});
 
   /// Flush all registered span processors.
   void forceFlush();

--- a/lib/src/sdk/instrumentation_library.dart
+++ b/lib/src/sdk/instrumentation_library.dart
@@ -4,6 +4,8 @@
 import '../../api.dart' as api;
 
 // Represents the instrumentation library.
+@Deprecated(
+    'This class will be removed in 0.18.0.  Use InstrumentationScope from SDK intead.')
 class InstrumentationLibrary implements api.InstrumentationLibrary {
   final String _name;
   final String _version;

--- a/lib/src/sdk/metrics/state/meter_provider_shared_state.dart
+++ b/lib/src/sdk/metrics/state/meter_provider_shared_state.dart
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
 import 'package:opentelemetry/sdk.dart';
-import 'package:opentelemetry/src/sdk/common/instrumentation_scope.dart';
 import 'package:opentelemetry/src/sdk/metrics/state/meter_shared_state.dart';
 import 'package:quiver/core.dart';
 

--- a/lib/src/sdk/platforms/web/trace/web_tracer_provider.dart
+++ b/lib/src/sdk/platforms/web/trace/web_tracer_provider.dart
@@ -36,10 +36,19 @@ class WebTracerProvider extends sdk.TracerProviderBase {
             spanLimits: spanLimits ?? sdk.SpanLimits());
 
   @override
-  api.Tracer getTracer(String name, {String version = ''}) {
+  api.Tracer getTracer(String name,
+      {String version = '',
+      String schemaUrl = '',
+      List<api.Attribute> attributes = const []}) {
     return tracers.putIfAbsent(
         '$name@$version',
-        () => Tracer(processors, resource, sampler, _timeProvider, idGenerator,
-            sdk.InstrumentationLibrary(name, version), spanLimits));
+        () => Tracer(
+            processors,
+            resource,
+            sampler,
+            _timeProvider,
+            idGenerator,
+            sdk.InstrumentationScope(name, version, schemaUrl, attributes),
+            spanLimits));
   }
 }

--- a/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pb.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pb.dart
@@ -1,12 +1,16 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/collector/trace/v1/trace_service.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:async' as $async;
 import 'dart:core' as $core;
@@ -16,23 +20,24 @@ import 'package:protobuf/protobuf.dart' as $pb;
 import '../../../trace/v1/trace.pb.dart' as $2;
 
 class ExportTraceServiceRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ExportTraceServiceRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.collector.trace.v1'), createEmptyInstance: create)
-    ..pc<$2.ResourceSpans>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'resourceSpans', $pb.PbFieldType.PM, subBuilder: $2.ResourceSpans.create)
-    ..hasRequiredFields = false
-  ;
-
-  ExportTraceServiceRequest._() : super();
   factory ExportTraceServiceRequest({
     $core.Iterable<$2.ResourceSpans>? resourceSpans,
   }) {
-    final _result = create();
+    final $result = create();
     if (resourceSpans != null) {
-      _result.resourceSpans.addAll(resourceSpans);
+      $result.resourceSpans.addAll(resourceSpans);
     }
-    return _result;
+    return $result;
   }
+  ExportTraceServiceRequest._() : super();
   factory ExportTraceServiceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory ExportTraceServiceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExportTraceServiceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.collector.trace.v1'), createEmptyInstance: create)
+    ..pc<$2.ResourceSpans>(1, _omitFieldNames ? '' : 'resourceSpans', $pb.PbFieldType.PM, subBuilder: $2.ResourceSpans.create)
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -42,8 +47,10 @@ class ExportTraceServiceRequest extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  ExportTraceServiceRequest copyWith(void Function(ExportTraceServiceRequest) updates) => super.copyWith((message) => updates(message as ExportTraceServiceRequest)) as ExportTraceServiceRequest; // ignore: deprecated_member_use
+  ExportTraceServiceRequest copyWith(void Function(ExportTraceServiceRequest) updates) => super.copyWith((message) => updates(message as ExportTraceServiceRequest)) as ExportTraceServiceRequest;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ExportTraceServiceRequest create() => ExportTraceServiceRequest._();
   ExportTraceServiceRequest createEmptyInstance() => create();
@@ -52,19 +59,25 @@ class ExportTraceServiceRequest extends $pb.GeneratedMessage {
   static ExportTraceServiceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExportTraceServiceRequest>(create);
   static ExportTraceServiceRequest? _defaultInstance;
 
+  /// An array of ResourceSpans.
+  /// For data coming from a single resource this array will typically contain one
+  /// element. Intermediary nodes (such as OpenTelemetry Collector) that receive
+  /// data from multiple origins typically batch the data before forwarding further and
+  /// in that case this array will contain multiple elements.
   @$pb.TagNumber(1)
   $core.List<$2.ResourceSpans> get resourceSpans => $_getList(0);
 }
 
 class ExportTraceServiceResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ExportTraceServiceResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.collector.trace.v1'), createEmptyInstance: create)
+  factory ExportTraceServiceResponse() => create();
+  ExportTraceServiceResponse._() : super();
+  factory ExportTraceServiceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ExportTraceServiceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExportTraceServiceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.collector.trace.v1'), createEmptyInstance: create)
     ..hasRequiredFields = false
   ;
 
-  ExportTraceServiceResponse._() : super();
-  factory ExportTraceServiceResponse() => create();
-  factory ExportTraceServiceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ExportTraceServiceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -74,8 +87,10 @@ class ExportTraceServiceResponse extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  ExportTraceServiceResponse copyWith(void Function(ExportTraceServiceResponse) updates) => super.copyWith((message) => updates(message as ExportTraceServiceResponse)) as ExportTraceServiceResponse; // ignore: deprecated_member_use
+  ExportTraceServiceResponse copyWith(void Function(ExportTraceServiceResponse) updates) => super.copyWith((message) => updates(message as ExportTraceServiceResponse)) as ExportTraceServiceResponse;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ExportTraceServiceResponse create() => ExportTraceServiceResponse._();
   ExportTraceServiceResponse createEmptyInstance() => create();
@@ -89,9 +104,11 @@ class TraceServiceApi {
   $pb.RpcClient _client;
   TraceServiceApi(this._client);
 
-  $async.Future<ExportTraceServiceResponse> export($pb.ClientContext? ctx, ExportTraceServiceRequest request) {
-    var emptyResponse = ExportTraceServiceResponse();
-    return _client.invoke<ExportTraceServiceResponse>(ctx, 'TraceService', 'Export', request, emptyResponse);
-  }
+  $async.Future<ExportTraceServiceResponse> export($pb.ClientContext? ctx, ExportTraceServiceRequest request) =>
+    _client.invoke<ExportTraceServiceResponse>(ctx, 'TraceService', 'Export', request, ExportTraceServiceResponse())
+  ;
 }
 
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pb.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pb.dart
@@ -15,6 +15,7 @@
 import 'dart:async' as $async;
 import 'dart:core' as $core;
 
+import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 import '../../../trace/v1/trace.pb.dart' as $2;
@@ -69,12 +70,21 @@ class ExportTraceServiceRequest extends $pb.GeneratedMessage {
 }
 
 class ExportTraceServiceResponse extends $pb.GeneratedMessage {
-  factory ExportTraceServiceResponse() => create();
+  factory ExportTraceServiceResponse({
+    ExportTracePartialSuccess? partialSuccess,
+  }) {
+    final $result = create();
+    if (partialSuccess != null) {
+      $result.partialSuccess = partialSuccess;
+    }
+    return $result;
+  }
   ExportTraceServiceResponse._() : super();
   factory ExportTraceServiceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory ExportTraceServiceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExportTraceServiceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.collector.trace.v1'), createEmptyInstance: create)
+    ..aOM<ExportTracePartialSuccess>(1, _omitFieldNames ? '' : 'partialSuccess', subBuilder: ExportTracePartialSuccess.create)
     ..hasRequiredFields = false
   ;
 
@@ -98,6 +108,107 @@ class ExportTraceServiceResponse extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ExportTraceServiceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExportTraceServiceResponse>(create);
   static ExportTraceServiceResponse? _defaultInstance;
+
+  ///  The details of a partially successful export request.
+  ///
+  ///  If the request is only partially accepted
+  ///  (i.e. when the server accepts only parts of the data and rejects the rest)
+  ///  the server MUST initialize the `partial_success` field and MUST
+  ///  set the `rejected_<signal>` with the number of items it rejected.
+  ///
+  ///  Servers MAY also make use of the `partial_success` field to convey
+  ///  warnings/suggestions to senders even when the request was fully accepted.
+  ///  In such cases, the `rejected_<signal>` MUST have a value of `0` and
+  ///  the `error_message` MUST be non-empty.
+  ///
+  ///  A `partial_success` message with an empty value (rejected_<signal> = 0 and
+  ///  `error_message` = "") is equivalent to it not being set/present. Senders
+  ///  SHOULD interpret it the same way as in the full success case.
+  @$pb.TagNumber(1)
+  ExportTracePartialSuccess get partialSuccess => $_getN(0);
+  @$pb.TagNumber(1)
+  set partialSuccess(ExportTracePartialSuccess v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPartialSuccess() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPartialSuccess() => clearField(1);
+  @$pb.TagNumber(1)
+  ExportTracePartialSuccess ensurePartialSuccess() => $_ensure(0);
+}
+
+class ExportTracePartialSuccess extends $pb.GeneratedMessage {
+  factory ExportTracePartialSuccess({
+    $fixnum.Int64? rejectedSpans,
+    $core.String? errorMessage,
+  }) {
+    final $result = create();
+    if (rejectedSpans != null) {
+      $result.rejectedSpans = rejectedSpans;
+    }
+    if (errorMessage != null) {
+      $result.errorMessage = errorMessage;
+    }
+    return $result;
+  }
+  ExportTracePartialSuccess._() : super();
+  factory ExportTracePartialSuccess.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ExportTracePartialSuccess.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExportTracePartialSuccess', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.collector.trace.v1'), createEmptyInstance: create)
+    ..aInt64(1, _omitFieldNames ? '' : 'rejectedSpans')
+    ..aOS(2, _omitFieldNames ? '' : 'errorMessage')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ExportTracePartialSuccess clone() => ExportTracePartialSuccess()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ExportTracePartialSuccess copyWith(void Function(ExportTracePartialSuccess) updates) => super.copyWith((message) => updates(message as ExportTracePartialSuccess)) as ExportTracePartialSuccess;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static ExportTracePartialSuccess create() => ExportTracePartialSuccess._();
+  ExportTracePartialSuccess createEmptyInstance() => create();
+  static $pb.PbList<ExportTracePartialSuccess> createRepeated() => $pb.PbList<ExportTracePartialSuccess>();
+  @$core.pragma('dart2js:noInline')
+  static ExportTracePartialSuccess getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExportTracePartialSuccess>(create);
+  static ExportTracePartialSuccess? _defaultInstance;
+
+  ///  The number of rejected spans.
+  ///
+  ///  A `rejected_<signal>` field holding a `0` value indicates that the
+  ///  request was fully accepted.
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get rejectedSpans => $_getI64(0);
+  @$pb.TagNumber(1)
+  set rejectedSpans($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRejectedSpans() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRejectedSpans() => clearField(1);
+
+  ///  A developer-facing human-readable message in English. It should be used
+  ///  either to explain why the server rejected parts of the data during a partial
+  ///  success or to convey warnings/suggestions during a full success. The message
+  ///  should offer guidance on how users can address such issues.
+  ///
+  ///  error_message is an optional field. An error_message with an empty value
+  ///  is equivalent to it not being set.
+  @$pb.TagNumber(2)
+  $core.String get errorMessage => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set errorMessage($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasErrorMessage() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearErrorMessage() => clearField(2);
 }
 
 class TraceServiceApi {

--- a/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pbenum.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pbenum.dart
@@ -1,10 +1,14 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/collector/trace/v1/trace_service.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 

--- a/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pbjson.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pbjson.dart
@@ -1,46 +1,56 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/collector/trace/v1/trace_service.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
-import 'dart:core' as $core;
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
-import '../../../trace/v1/trace.pbjson.dart' as $2;
-import '../../../resource/v1/resource.pbjson.dart' as $1;
+
 import '../../../common/v1/common.pbjson.dart' as $0;
+import '../../../resource/v1/resource.pbjson.dart' as $1;
+import '../../../trace/v1/trace.pbjson.dart' as $2;
 
 @$core.Deprecated('Use exportTraceServiceRequestDescriptor instead')
-const ExportTraceServiceRequest$json = const {
+const ExportTraceServiceRequest$json = {
   '1': 'ExportTraceServiceRequest',
-  '2': const [
-    const {'1': 'resource_spans', '3': 1, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.ResourceSpans', '10': 'resourceSpans'},
+  '2': [
+    {'1': 'resource_spans', '3': 1, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.ResourceSpans', '10': 'resourceSpans'},
   ],
 };
 
 /// Descriptor for `ExportTraceServiceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List exportTraceServiceRequestDescriptor = $convert.base64Decode('ChlFeHBvcnRUcmFjZVNlcnZpY2VSZXF1ZXN0ElIKDnJlc291cmNlX3NwYW5zGAEgAygLMisub3BlbnRlbGVtZXRyeS5wcm90by50cmFjZS52MS5SZXNvdXJjZVNwYW5zUg1yZXNvdXJjZVNwYW5z');
+final $typed_data.Uint8List exportTraceServiceRequestDescriptor = $convert.base64Decode(
+    'ChlFeHBvcnRUcmFjZVNlcnZpY2VSZXF1ZXN0ElIKDnJlc291cmNlX3NwYW5zGAEgAygLMisub3'
+    'BlbnRlbGVtZXRyeS5wcm90by50cmFjZS52MS5SZXNvdXJjZVNwYW5zUg1yZXNvdXJjZVNwYW5z');
+
 @$core.Deprecated('Use exportTraceServiceResponseDescriptor instead')
-const ExportTraceServiceResponse$json = const {
+const ExportTraceServiceResponse$json = {
   '1': 'ExportTraceServiceResponse',
 };
 
 /// Descriptor for `ExportTraceServiceResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List exportTraceServiceResponseDescriptor = $convert.base64Decode('ChpFeHBvcnRUcmFjZVNlcnZpY2VSZXNwb25zZQ==');
-const $core.Map<$core.String, $core.dynamic> TraceServiceBase$json = const {
+final $typed_data.Uint8List exportTraceServiceResponseDescriptor = $convert.base64Decode(
+    'ChpFeHBvcnRUcmFjZVNlcnZpY2VSZXNwb25zZQ==');
+
+const $core.Map<$core.String, $core.dynamic> TraceServiceBase$json = {
   '1': 'TraceService',
-  '2': const [
-    const {'1': 'Export', '2': '.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest', '3': '.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse', '4': const {}},
+  '2': [
+    {'1': 'Export', '2': '.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest', '3': '.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse', '4': {}},
   ],
 };
 
 @$core.Deprecated('Use traceServiceDescriptor instead')
-const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TraceServiceBase$messageJson = const {
+const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TraceServiceBase$messageJson = {
   '.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest': ExportTraceServiceRequest$json,
   '.opentelemetry.proto.trace.v1.ResourceSpans': $2.ResourceSpans$json,
   '.opentelemetry.proto.resource.v1.Resource': $1.Resource$json,
@@ -58,4 +68,8 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TraceServi
 };
 
 /// Descriptor for `TraceService`. Decode as a `google.protobuf.ServiceDescriptorProto`.
-final $typed_data.Uint8List traceServiceDescriptor = $convert.base64Decode('CgxUcmFjZVNlcnZpY2USkQEKBkV4cG9ydBJBLm9wZW50ZWxlbWV0cnkucHJvdG8uY29sbGVjdG9yLnRyYWNlLnYxLkV4cG9ydFRyYWNlU2VydmljZVJlcXVlc3QaQi5vcGVudGVsZW1ldHJ5LnByb3RvLmNvbGxlY3Rvci50cmFjZS52MS5FeHBvcnRUcmFjZVNlcnZpY2VSZXNwb25zZSIA');
+final $typed_data.Uint8List traceServiceDescriptor = $convert.base64Decode(
+    'CgxUcmFjZVNlcnZpY2USkQEKBkV4cG9ydBJBLm9wZW50ZWxlbWV0cnkucHJvdG8uY29sbGVjdG'
+    '9yLnRyYWNlLnYxLkV4cG9ydFRyYWNlU2VydmljZVJlcXVlc3QaQi5vcGVudGVsZW1ldHJ5LnBy'
+    'b3RvLmNvbGxlY3Rvci50cmFjZS52MS5FeHBvcnRUcmFjZVNlcnZpY2VSZXNwb25zZSIA');
+

--- a/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pbjson.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pbjson.dart
@@ -36,11 +36,30 @@ final $typed_data.Uint8List exportTraceServiceRequestDescriptor = $convert.base6
 @$core.Deprecated('Use exportTraceServiceResponseDescriptor instead')
 const ExportTraceServiceResponse$json = {
   '1': 'ExportTraceServiceResponse',
+  '2': [
+    {'1': 'partial_success', '3': 1, '4': 1, '5': 11, '6': '.opentelemetry.proto.collector.trace.v1.ExportTracePartialSuccess', '10': 'partialSuccess'},
+  ],
 };
 
 /// Descriptor for `ExportTraceServiceResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List exportTraceServiceResponseDescriptor = $convert.base64Decode(
-    'ChpFeHBvcnRUcmFjZVNlcnZpY2VSZXNwb25zZQ==');
+    'ChpFeHBvcnRUcmFjZVNlcnZpY2VSZXNwb25zZRJqCg9wYXJ0aWFsX3N1Y2Nlc3MYASABKAsyQS'
+    '5vcGVudGVsZW1ldHJ5LnByb3RvLmNvbGxlY3Rvci50cmFjZS52MS5FeHBvcnRUcmFjZVBhcnRp'
+    'YWxTdWNjZXNzUg5wYXJ0aWFsU3VjY2Vzcw==');
+
+@$core.Deprecated('Use exportTracePartialSuccessDescriptor instead')
+const ExportTracePartialSuccess$json = {
+  '1': 'ExportTracePartialSuccess',
+  '2': [
+    {'1': 'rejected_spans', '3': 1, '4': 1, '5': 3, '10': 'rejectedSpans'},
+    {'1': 'error_message', '3': 2, '4': 1, '5': 9, '10': 'errorMessage'},
+  ],
+};
+
+/// Descriptor for `ExportTracePartialSuccess`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List exportTracePartialSuccessDescriptor = $convert.base64Decode(
+    'ChlFeHBvcnRUcmFjZVBhcnRpYWxTdWNjZXNzEiUKDnJlamVjdGVkX3NwYW5zGAEgASgDUg1yZW'
+    'plY3RlZFNwYW5zEiMKDWVycm9yX21lc3NhZ2UYAiABKAlSDGVycm9yTWVzc2FnZQ==');
 
 const $core.Map<$core.String, $core.dynamic> TraceServiceBase$json = {
   '1': 'TraceService',
@@ -58,13 +77,14 @@ const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TraceServi
   '.opentelemetry.proto.common.v1.AnyValue': $0.AnyValue$json,
   '.opentelemetry.proto.common.v1.ArrayValue': $0.ArrayValue$json,
   '.opentelemetry.proto.common.v1.KeyValueList': $0.KeyValueList$json,
-  '.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans': $2.InstrumentationLibrarySpans$json,
-  '.opentelemetry.proto.common.v1.InstrumentationLibrary': $0.InstrumentationLibrary$json,
+  '.opentelemetry.proto.trace.v1.ScopeSpans': $2.ScopeSpans$json,
+  '.opentelemetry.proto.common.v1.InstrumentationScope': $0.InstrumentationScope$json,
   '.opentelemetry.proto.trace.v1.Span': $2.Span$json,
   '.opentelemetry.proto.trace.v1.Span.Event': $2.Span_Event$json,
   '.opentelemetry.proto.trace.v1.Span.Link': $2.Span_Link$json,
   '.opentelemetry.proto.trace.v1.Status': $2.Status$json,
   '.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse': ExportTraceServiceResponse$json,
+  '.opentelemetry.proto.collector.trace.v1.ExportTracePartialSuccess': ExportTracePartialSuccess$json,
 };
 
 /// Descriptor for `TraceService`. Decode as a `google.protobuf.ServiceDescriptorProto`.

--- a/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pbserver.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/collector/trace/v1/trace_service.pbserver.dart
@@ -1,18 +1,23 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/collector/trace/v1/trace_service.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:async' as $async;
+import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import 'dart:core' as $core;
 import 'trace_service.pb.dart' as $3;
 import 'trace_service.pbjson.dart';
 
@@ -21,17 +26,17 @@ export 'trace_service.pb.dart';
 abstract class TraceServiceBase extends $pb.GeneratedService {
   $async.Future<$3.ExportTraceServiceResponse> export($pb.ServerContext ctx, $3.ExportTraceServiceRequest request);
 
-  $pb.GeneratedMessage createRequest($core.String method) {
-    switch (method) {
+  $pb.GeneratedMessage createRequest($core.String methodName) {
+    switch (methodName) {
       case 'Export': return $3.ExportTraceServiceRequest();
-      default: throw $core.ArgumentError('Unknown method: $method');
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 
-  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String method, $pb.GeneratedMessage request) {
-    switch (method) {
+  $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String methodName, $pb.GeneratedMessage request) {
+    switch (methodName) {
       case 'Export': return this.export(ctx, request as $3.ExportTraceServiceRequest);
-      default: throw $core.ArgumentError('Unknown method: $method');
+      default: throw $core.ArgumentError('Unknown method: $methodName');
     }
   }
 

--- a/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pb.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pb.dart
@@ -277,6 +277,8 @@ class KeyValueList extends $pb.GeneratedMessage {
 
   /// A collection of key/value pairs of key-value pairs. The list may be empty (may
   /// contain 0 elements).
+  /// The keys MUST be unique (it is not allowed to have more than one
+  /// value with the same key).
   @$pb.TagNumber(1)
   $core.List<KeyValue> get values => $_getList(0);
 }
@@ -349,78 +351,14 @@ class KeyValue extends $pb.GeneratedMessage {
   AnyValue ensureValue() => $_ensure(1);
 }
 
-/// StringKeyValue is a pair of key/value strings. This is the simpler (and faster) version
-/// of KeyValue that only supports string values.
-class StringKeyValue extends $pb.GeneratedMessage {
-  factory StringKeyValue({
-    $core.String? key,
-    $core.String? value,
-  }) {
-    final $result = create();
-    if (key != null) {
-      $result.key = key;
-    }
-    if (value != null) {
-      $result.value = value;
-    }
-    return $result;
-  }
-  StringKeyValue._() : super();
-  factory StringKeyValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory StringKeyValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StringKeyValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
-    ..aOS(1, _omitFieldNames ? '' : 'key')
-    ..aOS(2, _omitFieldNames ? '' : 'value')
-    ..hasRequiredFields = false
-  ;
-
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  StringKeyValue clone() => StringKeyValue()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  StringKeyValue copyWith(void Function(StringKeyValue) updates) => super.copyWith((message) => updates(message as StringKeyValue)) as StringKeyValue;
-
-  $pb.BuilderInfo get info_ => _i;
-
-  @$core.pragma('dart2js:noInline')
-  static StringKeyValue create() => StringKeyValue._();
-  StringKeyValue createEmptyInstance() => create();
-  static $pb.PbList<StringKeyValue> createRepeated() => $pb.PbList<StringKeyValue>();
-  @$core.pragma('dart2js:noInline')
-  static StringKeyValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StringKeyValue>(create);
-  static StringKeyValue? _defaultInstance;
-
-  @$pb.TagNumber(1)
-  $core.String get key => $_getSZ(0);
-  @$pb.TagNumber(1)
-  set key($core.String v) { $_setString(0, v); }
-  @$pb.TagNumber(1)
-  $core.bool hasKey() => $_has(0);
-  @$pb.TagNumber(1)
-  void clearKey() => clearField(1);
-
-  @$pb.TagNumber(2)
-  $core.String get value => $_getSZ(1);
-  @$pb.TagNumber(2)
-  set value($core.String v) { $_setString(1, v); }
-  @$pb.TagNumber(2)
-  $core.bool hasValue() => $_has(1);
-  @$pb.TagNumber(2)
-  void clearValue() => clearField(2);
-}
-
-/// InstrumentationLibrary is a message representing the instrumentation library information
+/// InstrumentationScope is a message representing the instrumentation scope information
 /// such as the fully qualified name and version.
-class InstrumentationLibrary extends $pb.GeneratedMessage {
-  factory InstrumentationLibrary({
+class InstrumentationScope extends $pb.GeneratedMessage {
+  factory InstrumentationScope({
     $core.String? name,
     $core.String? version,
+    $core.Iterable<KeyValue>? attributes,
+    $core.int? droppedAttributesCount,
   }) {
     final $result = create();
     if (name != null) {
@@ -429,15 +367,23 @@ class InstrumentationLibrary extends $pb.GeneratedMessage {
     if (version != null) {
       $result.version = version;
     }
+    if (attributes != null) {
+      $result.attributes.addAll(attributes);
+    }
+    if (droppedAttributesCount != null) {
+      $result.droppedAttributesCount = droppedAttributesCount;
+    }
     return $result;
   }
-  InstrumentationLibrary._() : super();
-  factory InstrumentationLibrary.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory InstrumentationLibrary.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  InstrumentationScope._() : super();
+  factory InstrumentationScope.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory InstrumentationScope.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'InstrumentationLibrary', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'InstrumentationScope', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOS(2, _omitFieldNames ? '' : 'version')
+    ..pc<KeyValue>(3, _omitFieldNames ? '' : 'attributes', $pb.PbFieldType.PM, subBuilder: KeyValue.create)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'droppedAttributesCount', $pb.PbFieldType.OU3)
     ..hasRequiredFields = false
   ;
 
@@ -445,24 +391,24 @@ class InstrumentationLibrary extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
   'Will be removed in next major version')
-  InstrumentationLibrary clone() => InstrumentationLibrary()..mergeFromMessage(this);
+  InstrumentationScope clone() => InstrumentationScope()..mergeFromMessage(this);
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  InstrumentationLibrary copyWith(void Function(InstrumentationLibrary) updates) => super.copyWith((message) => updates(message as InstrumentationLibrary)) as InstrumentationLibrary;
+  InstrumentationScope copyWith(void Function(InstrumentationScope) updates) => super.copyWith((message) => updates(message as InstrumentationScope)) as InstrumentationScope;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static InstrumentationLibrary create() => InstrumentationLibrary._();
-  InstrumentationLibrary createEmptyInstance() => create();
-  static $pb.PbList<InstrumentationLibrary> createRepeated() => $pb.PbList<InstrumentationLibrary>();
+  static InstrumentationScope create() => InstrumentationScope._();
+  InstrumentationScope createEmptyInstance() => create();
+  static $pb.PbList<InstrumentationScope> createRepeated() => $pb.PbList<InstrumentationScope>();
   @$core.pragma('dart2js:noInline')
-  static InstrumentationLibrary getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InstrumentationLibrary>(create);
-  static InstrumentationLibrary? _defaultInstance;
+  static InstrumentationScope getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InstrumentationScope>(create);
+  static InstrumentationScope? _defaultInstance;
 
-  /// An empty instrumentation library name means the name is unknown.
+  /// An empty instrumentation scope name means the name is unknown.
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -480,6 +426,21 @@ class InstrumentationLibrary extends $pb.GeneratedMessage {
   $core.bool hasVersion() => $_has(1);
   @$pb.TagNumber(2)
   void clearVersion() => clearField(2);
+
+  /// Additional attributes that describe the scope. [Optional].
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
+  @$pb.TagNumber(3)
+  $core.List<KeyValue> get attributes => $_getList(2);
+
+  @$pb.TagNumber(4)
+  $core.int get droppedAttributesCount => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set droppedAttributesCount($core.int v) { $_setUnsignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasDroppedAttributesCount() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearDroppedAttributesCount() => clearField(4);
 }
 
 

--- a/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pb.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pb.dart
@@ -1,12 +1,16 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/common/v1/common.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 
@@ -24,7 +28,47 @@ enum AnyValue_Value {
   notSet
 }
 
+/// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+/// primitive value such as a string or integer or it may contain an arbitrary nested
+/// object containing arrays, key-value lists and primitives.
 class AnyValue extends $pb.GeneratedMessage {
+  factory AnyValue({
+    $core.String? stringValue,
+    $core.bool? boolValue,
+    $fixnum.Int64? intValue,
+    $core.double? doubleValue,
+    ArrayValue? arrayValue,
+    KeyValueList? kvlistValue,
+    $core.List<$core.int>? bytesValue,
+  }) {
+    final $result = create();
+    if (stringValue != null) {
+      $result.stringValue = stringValue;
+    }
+    if (boolValue != null) {
+      $result.boolValue = boolValue;
+    }
+    if (intValue != null) {
+      $result.intValue = intValue;
+    }
+    if (doubleValue != null) {
+      $result.doubleValue = doubleValue;
+    }
+    if (arrayValue != null) {
+      $result.arrayValue = arrayValue;
+    }
+    if (kvlistValue != null) {
+      $result.kvlistValue = kvlistValue;
+    }
+    if (bytesValue != null) {
+      $result.bytesValue = bytesValue;
+    }
+    return $result;
+  }
+  AnyValue._() : super();
+  factory AnyValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AnyValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
   static const $core.Map<$core.int, AnyValue_Value> _AnyValue_ValueByTag = {
     1 : AnyValue_Value.stringValue,
     2 : AnyValue_Value.boolValue,
@@ -35,54 +79,18 @@ class AnyValue extends $pb.GeneratedMessage {
     7 : AnyValue_Value.bytesValue,
     0 : AnyValue_Value.notSet
   };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AnyValue', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'AnyValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
     ..oo(0, [1, 2, 3, 4, 5, 6, 7])
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'stringValue')
-    ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'boolValue')
-    ..aInt64(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'intValue')
-    ..a<$core.double>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'doubleValue', $pb.PbFieldType.OD)
-    ..aOM<ArrayValue>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'arrayValue', subBuilder: ArrayValue.create)
-    ..aOM<KeyValueList>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'kvlistValue', subBuilder: KeyValueList.create)
-    ..a<$core.List<$core.int>>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'bytesValue', $pb.PbFieldType.OY)
+    ..aOS(1, _omitFieldNames ? '' : 'stringValue')
+    ..aOB(2, _omitFieldNames ? '' : 'boolValue')
+    ..aInt64(3, _omitFieldNames ? '' : 'intValue')
+    ..a<$core.double>(4, _omitFieldNames ? '' : 'doubleValue', $pb.PbFieldType.OD)
+    ..aOM<ArrayValue>(5, _omitFieldNames ? '' : 'arrayValue', subBuilder: ArrayValue.create)
+    ..aOM<KeyValueList>(6, _omitFieldNames ? '' : 'kvlistValue', subBuilder: KeyValueList.create)
+    ..a<$core.List<$core.int>>(7, _omitFieldNames ? '' : 'bytesValue', $pb.PbFieldType.OY)
     ..hasRequiredFields = false
   ;
 
-  AnyValue._() : super();
-  factory AnyValue({
-    $core.String? stringValue,
-    $core.bool? boolValue,
-    $fixnum.Int64? intValue,
-    $core.double? doubleValue,
-    ArrayValue? arrayValue,
-    KeyValueList? kvlistValue,
-    $core.List<$core.int>? bytesValue,
-  }) {
-    final _result = create();
-    if (stringValue != null) {
-      _result.stringValue = stringValue;
-    }
-    if (boolValue != null) {
-      _result.boolValue = boolValue;
-    }
-    if (intValue != null) {
-      _result.intValue = intValue;
-    }
-    if (doubleValue != null) {
-      _result.doubleValue = doubleValue;
-    }
-    if (arrayValue != null) {
-      _result.arrayValue = arrayValue;
-    }
-    if (kvlistValue != null) {
-      _result.kvlistValue = kvlistValue;
-    }
-    if (bytesValue != null) {
-      _result.bytesValue = bytesValue;
-    }
-    return _result;
-  }
-  factory AnyValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AnyValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -92,8 +100,10 @@ class AnyValue extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  AnyValue copyWith(void Function(AnyValue) updates) => super.copyWith((message) => updates(message as AnyValue)) as AnyValue; // ignore: deprecated_member_use
+  AnyValue copyWith(void Function(AnyValue) updates) => super.copyWith((message) => updates(message as AnyValue)) as AnyValue;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static AnyValue create() => AnyValue._();
   AnyValue createEmptyInstance() => create();
@@ -173,24 +183,27 @@ class AnyValue extends $pb.GeneratedMessage {
   void clearBytesValue() => clearField(7);
 }
 
+/// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+/// since oneof in AnyValue does not allow repeated fields.
 class ArrayValue extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ArrayValue', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
-    ..pc<AnyValue>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'values', $pb.PbFieldType.PM, subBuilder: AnyValue.create)
-    ..hasRequiredFields = false
-  ;
-
-  ArrayValue._() : super();
   factory ArrayValue({
     $core.Iterable<AnyValue>? values,
   }) {
-    final _result = create();
+    final $result = create();
     if (values != null) {
-      _result.values.addAll(values);
+      $result.values.addAll(values);
     }
-    return _result;
+    return $result;
   }
+  ArrayValue._() : super();
   factory ArrayValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory ArrayValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ArrayValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
+    ..pc<AnyValue>(1, _omitFieldNames ? '' : 'values', $pb.PbFieldType.PM, subBuilder: AnyValue.create)
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -200,8 +213,10 @@ class ArrayValue extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  ArrayValue copyWith(void Function(ArrayValue) updates) => super.copyWith((message) => updates(message as ArrayValue)) as ArrayValue; // ignore: deprecated_member_use
+  ArrayValue copyWith(void Function(ArrayValue) updates) => super.copyWith((message) => updates(message as ArrayValue)) as ArrayValue;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ArrayValue create() => ArrayValue._();
   ArrayValue createEmptyInstance() => create();
@@ -210,28 +225,35 @@ class ArrayValue extends $pb.GeneratedMessage {
   static ArrayValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ArrayValue>(create);
   static ArrayValue? _defaultInstance;
 
+  /// Array of values. The array may be empty (contain 0 elements).
   @$pb.TagNumber(1)
   $core.List<AnyValue> get values => $_getList(0);
 }
 
+/// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+/// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+/// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+/// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+/// are semantically equivalent.
 class KeyValueList extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'KeyValueList', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
-    ..pc<KeyValue>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'values', $pb.PbFieldType.PM, subBuilder: KeyValue.create)
-    ..hasRequiredFields = false
-  ;
-
-  KeyValueList._() : super();
   factory KeyValueList({
     $core.Iterable<KeyValue>? values,
   }) {
-    final _result = create();
+    final $result = create();
     if (values != null) {
-      _result.values.addAll(values);
+      $result.values.addAll(values);
     }
-    return _result;
+    return $result;
   }
+  KeyValueList._() : super();
   factory KeyValueList.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory KeyValueList.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'KeyValueList', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
+    ..pc<KeyValue>(1, _omitFieldNames ? '' : 'values', $pb.PbFieldType.PM, subBuilder: KeyValue.create)
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -241,8 +263,10 @@ class KeyValueList extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  KeyValueList copyWith(void Function(KeyValueList) updates) => super.copyWith((message) => updates(message as KeyValueList)) as KeyValueList; // ignore: deprecated_member_use
+  KeyValueList copyWith(void Function(KeyValueList) updates) => super.copyWith((message) => updates(message as KeyValueList)) as KeyValueList;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static KeyValueList create() => KeyValueList._();
   KeyValueList createEmptyInstance() => create();
@@ -251,33 +275,38 @@ class KeyValueList extends $pb.GeneratedMessage {
   static KeyValueList getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<KeyValueList>(create);
   static KeyValueList? _defaultInstance;
 
+  /// A collection of key/value pairs of key-value pairs. The list may be empty (may
+  /// contain 0 elements).
   @$pb.TagNumber(1)
   $core.List<KeyValue> get values => $_getList(0);
 }
 
+/// KeyValue is a key-value pair that is used to store Span attributes, Link
+/// attributes, etc.
 class KeyValue extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'KeyValue', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'key')
-    ..aOM<AnyValue>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', subBuilder: AnyValue.create)
-    ..hasRequiredFields = false
-  ;
-
-  KeyValue._() : super();
   factory KeyValue({
     $core.String? key,
     AnyValue? value,
   }) {
-    final _result = create();
+    final $result = create();
     if (key != null) {
-      _result.key = key;
+      $result.key = key;
     }
     if (value != null) {
-      _result.value = value;
+      $result.value = value;
     }
-    return _result;
+    return $result;
   }
+  KeyValue._() : super();
   factory KeyValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory KeyValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'KeyValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'key')
+    ..aOM<AnyValue>(2, _omitFieldNames ? '' : 'value', subBuilder: AnyValue.create)
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -287,8 +316,10 @@ class KeyValue extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  KeyValue copyWith(void Function(KeyValue) updates) => super.copyWith((message) => updates(message as KeyValue)) as KeyValue; // ignore: deprecated_member_use
+  KeyValue copyWith(void Function(KeyValue) updates) => super.copyWith((message) => updates(message as KeyValue)) as KeyValue;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static KeyValue create() => KeyValue._();
   KeyValue createEmptyInstance() => create();
@@ -318,29 +349,32 @@ class KeyValue extends $pb.GeneratedMessage {
   AnyValue ensureValue() => $_ensure(1);
 }
 
+/// StringKeyValue is a pair of key/value strings. This is the simpler (and faster) version
+/// of KeyValue that only supports string values.
 class StringKeyValue extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'StringKeyValue', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'key')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value')
-    ..hasRequiredFields = false
-  ;
-
-  StringKeyValue._() : super();
   factory StringKeyValue({
     $core.String? key,
     $core.String? value,
   }) {
-    final _result = create();
+    final $result = create();
     if (key != null) {
-      _result.key = key;
+      $result.key = key;
     }
     if (value != null) {
-      _result.value = value;
+      $result.value = value;
     }
-    return _result;
+    return $result;
   }
+  StringKeyValue._() : super();
   factory StringKeyValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory StringKeyValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StringKeyValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'key')
+    ..aOS(2, _omitFieldNames ? '' : 'value')
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -350,8 +384,10 @@ class StringKeyValue extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  StringKeyValue copyWith(void Function(StringKeyValue) updates) => super.copyWith((message) => updates(message as StringKeyValue)) as StringKeyValue; // ignore: deprecated_member_use
+  StringKeyValue copyWith(void Function(StringKeyValue) updates) => super.copyWith((message) => updates(message as StringKeyValue)) as StringKeyValue;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static StringKeyValue create() => StringKeyValue._();
   StringKeyValue createEmptyInstance() => create();
@@ -379,29 +415,32 @@ class StringKeyValue extends $pb.GeneratedMessage {
   void clearValue() => clearField(2);
 }
 
+/// InstrumentationLibrary is a message representing the instrumentation library information
+/// such as the fully qualified name and version.
 class InstrumentationLibrary extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'InstrumentationLibrary', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'version')
-    ..hasRequiredFields = false
-  ;
-
-  InstrumentationLibrary._() : super();
   factory InstrumentationLibrary({
     $core.String? name,
     $core.String? version,
   }) {
-    final _result = create();
+    final $result = create();
     if (name != null) {
-      _result.name = name;
+      $result.name = name;
     }
     if (version != null) {
-      _result.version = version;
+      $result.version = version;
     }
-    return _result;
+    return $result;
   }
+  InstrumentationLibrary._() : super();
   factory InstrumentationLibrary.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory InstrumentationLibrary.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'InstrumentationLibrary', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.common.v1'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOS(2, _omitFieldNames ? '' : 'version')
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -411,8 +450,10 @@ class InstrumentationLibrary extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  InstrumentationLibrary copyWith(void Function(InstrumentationLibrary) updates) => super.copyWith((message) => updates(message as InstrumentationLibrary)) as InstrumentationLibrary; // ignore: deprecated_member_use
+  InstrumentationLibrary copyWith(void Function(InstrumentationLibrary) updates) => super.copyWith((message) => updates(message as InstrumentationLibrary)) as InstrumentationLibrary;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static InstrumentationLibrary create() => InstrumentationLibrary._();
   InstrumentationLibrary createEmptyInstance() => create();
@@ -421,6 +462,7 @@ class InstrumentationLibrary extends $pb.GeneratedMessage {
   static InstrumentationLibrary getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InstrumentationLibrary>(create);
   static InstrumentationLibrary? _defaultInstance;
 
+  /// An empty instrumentation library name means the name is unknown.
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
@@ -440,3 +482,6 @@ class InstrumentationLibrary extends $pb.GeneratedMessage {
   void clearVersion() => clearField(2);
 }
 
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pbenum.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pbenum.dart
@@ -1,10 +1,14 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/common/v1/common.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 

--- a/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pbjson.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pbjson.dart
@@ -83,32 +83,21 @@ final $typed_data.Uint8List keyValueDescriptor = $convert.base64Decode(
     'CghLZXlWYWx1ZRIQCgNrZXkYASABKAlSA2tleRI9CgV2YWx1ZRgCIAEoCzInLm9wZW50ZWxlbW'
     'V0cnkucHJvdG8uY29tbW9uLnYxLkFueVZhbHVlUgV2YWx1ZQ==');
 
-@$core.Deprecated('Use stringKeyValueDescriptor instead')
-const StringKeyValue$json = {
-  '1': 'StringKeyValue',
-  '2': [
-    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
-  ],
-  '7': {'3': true},
-};
-
-/// Descriptor for `StringKeyValue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stringKeyValueDescriptor = $convert.base64Decode(
-    'Cg5TdHJpbmdLZXlWYWx1ZRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdW'
-    'U6AhgB');
-
-@$core.Deprecated('Use instrumentationLibraryDescriptor instead')
-const InstrumentationLibrary$json = {
-  '1': 'InstrumentationLibrary',
+@$core.Deprecated('Use instrumentationScopeDescriptor instead')
+const InstrumentationScope$json = {
+  '1': 'InstrumentationScope',
   '2': [
     {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
     {'1': 'version', '3': 2, '4': 1, '5': 9, '10': 'version'},
+    {'1': 'attributes', '3': 3, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'attributes'},
+    {'1': 'dropped_attributes_count', '3': 4, '4': 1, '5': 13, '10': 'droppedAttributesCount'},
   ],
 };
 
-/// Descriptor for `InstrumentationLibrary`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List instrumentationLibraryDescriptor = $convert.base64Decode(
-    'ChZJbnN0cnVtZW50YXRpb25MaWJyYXJ5EhIKBG5hbWUYASABKAlSBG5hbWUSGAoHdmVyc2lvbh'
-    'gCIAEoCVIHdmVyc2lvbg==');
+/// Descriptor for `InstrumentationScope`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List instrumentationScopeDescriptor = $convert.base64Decode(
+    'ChRJbnN0cnVtZW50YXRpb25TY29wZRISCgRuYW1lGAEgASgJUgRuYW1lEhgKB3ZlcnNpb24YAi'
+    'ABKAlSB3ZlcnNpb24SRwoKYXR0cmlidXRlcxgDIAMoCzInLm9wZW50ZWxlbWV0cnkucHJvdG8u'
+    'Y29tbW9uLnYxLktleVZhbHVlUgphdHRyaWJ1dGVzEjgKGGRyb3BwZWRfYXR0cmlidXRlc19jb3'
+    'VudBgEIAEoDVIWZHJvcHBlZEF0dHJpYnV0ZXNDb3VudA==');
 

--- a/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pbjson.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pbjson.dart
@@ -1,86 +1,114 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/common/v1/common.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
-import 'dart:core' as $core;
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
+
 @$core.Deprecated('Use anyValueDescriptor instead')
-const AnyValue$json = const {
+const AnyValue$json = {
   '1': 'AnyValue',
-  '2': const [
-    const {'1': 'string_value', '3': 1, '4': 1, '5': 9, '9': 0, '10': 'stringValue'},
-    const {'1': 'bool_value', '3': 2, '4': 1, '5': 8, '9': 0, '10': 'boolValue'},
-    const {'1': 'int_value', '3': 3, '4': 1, '5': 3, '9': 0, '10': 'intValue'},
-    const {'1': 'double_value', '3': 4, '4': 1, '5': 1, '9': 0, '10': 'doubleValue'},
-    const {'1': 'array_value', '3': 5, '4': 1, '5': 11, '6': '.opentelemetry.proto.common.v1.ArrayValue', '9': 0, '10': 'arrayValue'},
-    const {'1': 'kvlist_value', '3': 6, '4': 1, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValueList', '9': 0, '10': 'kvlistValue'},
-    const {'1': 'bytes_value', '3': 7, '4': 1, '5': 12, '9': 0, '10': 'bytesValue'},
+  '2': [
+    {'1': 'string_value', '3': 1, '4': 1, '5': 9, '9': 0, '10': 'stringValue'},
+    {'1': 'bool_value', '3': 2, '4': 1, '5': 8, '9': 0, '10': 'boolValue'},
+    {'1': 'int_value', '3': 3, '4': 1, '5': 3, '9': 0, '10': 'intValue'},
+    {'1': 'double_value', '3': 4, '4': 1, '5': 1, '9': 0, '10': 'doubleValue'},
+    {'1': 'array_value', '3': 5, '4': 1, '5': 11, '6': '.opentelemetry.proto.common.v1.ArrayValue', '9': 0, '10': 'arrayValue'},
+    {'1': 'kvlist_value', '3': 6, '4': 1, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValueList', '9': 0, '10': 'kvlistValue'},
+    {'1': 'bytes_value', '3': 7, '4': 1, '5': 12, '9': 0, '10': 'bytesValue'},
   ],
-  '8': const [
-    const {'1': 'value'},
+  '8': [
+    {'1': 'value'},
   ],
 };
 
 /// Descriptor for `AnyValue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List anyValueDescriptor = $convert.base64Decode('CghBbnlWYWx1ZRIjCgxzdHJpbmdfdmFsdWUYASABKAlIAFILc3RyaW5nVmFsdWUSHwoKYm9vbF92YWx1ZRgCIAEoCEgAUglib29sVmFsdWUSHQoJaW50X3ZhbHVlGAMgASgDSABSCGludFZhbHVlEiMKDGRvdWJsZV92YWx1ZRgEIAEoAUgAUgtkb3VibGVWYWx1ZRJMCgthcnJheV92YWx1ZRgFIAEoCzIpLm9wZW50ZWxlbWV0cnkucHJvdG8uY29tbW9uLnYxLkFycmF5VmFsdWVIAFIKYXJyYXlWYWx1ZRJQCgxrdmxpc3RfdmFsdWUYBiABKAsyKy5vcGVudGVsZW1ldHJ5LnByb3RvLmNvbW1vbi52MS5LZXlWYWx1ZUxpc3RIAFILa3ZsaXN0VmFsdWUSIQoLYnl0ZXNfdmFsdWUYByABKAxIAFIKYnl0ZXNWYWx1ZUIHCgV2YWx1ZQ==');
+final $typed_data.Uint8List anyValueDescriptor = $convert.base64Decode(
+    'CghBbnlWYWx1ZRIjCgxzdHJpbmdfdmFsdWUYASABKAlIAFILc3RyaW5nVmFsdWUSHwoKYm9vbF'
+    '92YWx1ZRgCIAEoCEgAUglib29sVmFsdWUSHQoJaW50X3ZhbHVlGAMgASgDSABSCGludFZhbHVl'
+    'EiMKDGRvdWJsZV92YWx1ZRgEIAEoAUgAUgtkb3VibGVWYWx1ZRJMCgthcnJheV92YWx1ZRgFIA'
+    'EoCzIpLm9wZW50ZWxlbWV0cnkucHJvdG8uY29tbW9uLnYxLkFycmF5VmFsdWVIAFIKYXJyYXlW'
+    'YWx1ZRJQCgxrdmxpc3RfdmFsdWUYBiABKAsyKy5vcGVudGVsZW1ldHJ5LnByb3RvLmNvbW1vbi'
+    '52MS5LZXlWYWx1ZUxpc3RIAFILa3ZsaXN0VmFsdWUSIQoLYnl0ZXNfdmFsdWUYByABKAxIAFIK'
+    'Ynl0ZXNWYWx1ZUIHCgV2YWx1ZQ==');
+
 @$core.Deprecated('Use arrayValueDescriptor instead')
-const ArrayValue$json = const {
+const ArrayValue$json = {
   '1': 'ArrayValue',
-  '2': const [
-    const {'1': 'values', '3': 1, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.AnyValue', '10': 'values'},
+  '2': [
+    {'1': 'values', '3': 1, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.AnyValue', '10': 'values'},
   ],
 };
 
 /// Descriptor for `ArrayValue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List arrayValueDescriptor = $convert.base64Decode('CgpBcnJheVZhbHVlEj8KBnZhbHVlcxgBIAMoCzInLm9wZW50ZWxlbWV0cnkucHJvdG8uY29tbW9uLnYxLkFueVZhbHVlUgZ2YWx1ZXM=');
+final $typed_data.Uint8List arrayValueDescriptor = $convert.base64Decode(
+    'CgpBcnJheVZhbHVlEj8KBnZhbHVlcxgBIAMoCzInLm9wZW50ZWxlbWV0cnkucHJvdG8uY29tbW'
+    '9uLnYxLkFueVZhbHVlUgZ2YWx1ZXM=');
+
 @$core.Deprecated('Use keyValueListDescriptor instead')
-const KeyValueList$json = const {
+const KeyValueList$json = {
   '1': 'KeyValueList',
-  '2': const [
-    const {'1': 'values', '3': 1, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'values'},
+  '2': [
+    {'1': 'values', '3': 1, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'values'},
   ],
 };
 
 /// Descriptor for `KeyValueList`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List keyValueListDescriptor = $convert.base64Decode('CgxLZXlWYWx1ZUxpc3QSPwoGdmFsdWVzGAEgAygLMicub3BlbnRlbGVtZXRyeS5wcm90by5jb21tb24udjEuS2V5VmFsdWVSBnZhbHVlcw==');
+final $typed_data.Uint8List keyValueListDescriptor = $convert.base64Decode(
+    'CgxLZXlWYWx1ZUxpc3QSPwoGdmFsdWVzGAEgAygLMicub3BlbnRlbGVtZXRyeS5wcm90by5jb2'
+    '1tb24udjEuS2V5VmFsdWVSBnZhbHVlcw==');
+
 @$core.Deprecated('Use keyValueDescriptor instead')
-const KeyValue$json = const {
+const KeyValue$json = {
   '1': 'KeyValue',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.opentelemetry.proto.common.v1.AnyValue', '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.opentelemetry.proto.common.v1.AnyValue', '10': 'value'},
   ],
 };
 
 /// Descriptor for `KeyValue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List keyValueDescriptor = $convert.base64Decode('CghLZXlWYWx1ZRIQCgNrZXkYASABKAlSA2tleRI9CgV2YWx1ZRgCIAEoCzInLm9wZW50ZWxlbWV0cnkucHJvdG8uY29tbW9uLnYxLkFueVZhbHVlUgV2YWx1ZQ==');
+final $typed_data.Uint8List keyValueDescriptor = $convert.base64Decode(
+    'CghLZXlWYWx1ZRIQCgNrZXkYASABKAlSA2tleRI9CgV2YWx1ZRgCIAEoCzInLm9wZW50ZWxlbW'
+    'V0cnkucHJvdG8uY29tbW9uLnYxLkFueVZhbHVlUgV2YWx1ZQ==');
+
 @$core.Deprecated('Use stringKeyValueDescriptor instead')
-const StringKeyValue$json = const {
+const StringKeyValue$json = {
   '1': 'StringKeyValue',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'3': true},
+  '7': {'3': true},
 };
 
 /// Descriptor for `StringKeyValue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List stringKeyValueDescriptor = $convert.base64Decode('Cg5TdHJpbmdLZXlWYWx1ZRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AhgB');
+final $typed_data.Uint8List stringKeyValueDescriptor = $convert.base64Decode(
+    'Cg5TdHJpbmdLZXlWYWx1ZRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdW'
+    'U6AhgB');
+
 @$core.Deprecated('Use instrumentationLibraryDescriptor instead')
-const InstrumentationLibrary$json = const {
+const InstrumentationLibrary$json = {
   '1': 'InstrumentationLibrary',
-  '2': const [
-    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
-    const {'1': 'version', '3': 2, '4': 1, '5': 9, '10': 'version'},
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'version', '3': 2, '4': 1, '5': 9, '10': 'version'},
   ],
 };
 
 /// Descriptor for `InstrumentationLibrary`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List instrumentationLibraryDescriptor = $convert.base64Decode('ChZJbnN0cnVtZW50YXRpb25MaWJyYXJ5EhIKBG5hbWUYASABKAlSBG5hbWUSGAoHdmVyc2lvbhgCIAEoCVIHdmVyc2lvbg==');
+final $typed_data.Uint8List instrumentationLibraryDescriptor = $convert.base64Decode(
+    'ChZJbnN0cnVtZW50YXRpb25MaWJyYXJ5EhIKBG5hbWUYASABKAlSBG5hbWUSGAoHdmVyc2lvbh'
+    'gCIAEoCVIHdmVyc2lvbg==');
+

--- a/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pbserver.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/common/v1/common.pbserver.dart
@@ -1,12 +1,17 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/common/v1/common.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 export 'common.pb.dart';
 

--- a/lib/src/sdk/proto/opentelemetry/proto/resource/v1/resource.pb.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/resource/v1/resource.pb.dart
@@ -1,12 +1,16 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/resource/v1/resource.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 
@@ -14,29 +18,31 @@ import 'package:protobuf/protobuf.dart' as $pb;
 
 import '../../common/v1/common.pb.dart' as $0;
 
+/// Resource information.
 class Resource extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Resource', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.resource.v1'), createEmptyInstance: create)
-    ..pc<$0.KeyValue>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'attributes', $pb.PbFieldType.PM, subBuilder: $0.KeyValue.create)
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'droppedAttributesCount', $pb.PbFieldType.OU3)
-    ..hasRequiredFields = false
-  ;
-
-  Resource._() : super();
   factory Resource({
     $core.Iterable<$0.KeyValue>? attributes,
     $core.int? droppedAttributesCount,
   }) {
-    final _result = create();
+    final $result = create();
     if (attributes != null) {
-      _result.attributes.addAll(attributes);
+      $result.attributes.addAll(attributes);
     }
     if (droppedAttributesCount != null) {
-      _result.droppedAttributesCount = droppedAttributesCount;
+      $result.droppedAttributesCount = droppedAttributesCount;
     }
-    return _result;
+    return $result;
   }
+  Resource._() : super();
   factory Resource.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory Resource.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Resource', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.resource.v1'), createEmptyInstance: create)
+    ..pc<$0.KeyValue>(1, _omitFieldNames ? '' : 'attributes', $pb.PbFieldType.PM, subBuilder: $0.KeyValue.create)
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'droppedAttributesCount', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -46,8 +52,10 @@ class Resource extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Resource copyWith(void Function(Resource) updates) => super.copyWith((message) => updates(message as Resource)) as Resource; // ignore: deprecated_member_use
+  Resource copyWith(void Function(Resource) updates) => super.copyWith((message) => updates(message as Resource)) as Resource;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Resource create() => Resource._();
   Resource createEmptyInstance() => create();
@@ -56,9 +64,12 @@ class Resource extends $pb.GeneratedMessage {
   static Resource getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Resource>(create);
   static Resource? _defaultInstance;
 
+  /// Set of labels that describe the resource.
   @$pb.TagNumber(1)
   $core.List<$0.KeyValue> get attributes => $_getList(0);
 
+  /// dropped_attributes_count is the number of dropped attributes. If the value is 0, then
+  /// no attributes were dropped.
   @$pb.TagNumber(2)
   $core.int get droppedAttributesCount => $_getIZ(1);
   @$pb.TagNumber(2)
@@ -69,3 +80,6 @@ class Resource extends $pb.GeneratedMessage {
   void clearDroppedAttributesCount() => clearField(2);
 }
 
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/src/sdk/proto/opentelemetry/proto/resource/v1/resource.pb.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/resource/v1/resource.pb.dart
@@ -64,7 +64,9 @@ class Resource extends $pb.GeneratedMessage {
   static Resource getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Resource>(create);
   static Resource? _defaultInstance;
 
-  /// Set of labels that describe the resource.
+  /// Set of attributes that describe the resource.
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
   @$pb.TagNumber(1)
   $core.List<$0.KeyValue> get attributes => $_getList(0);
 

--- a/lib/src/sdk/proto/opentelemetry/proto/resource/v1/resource.pbenum.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/resource/v1/resource.pbenum.dart
@@ -1,10 +1,14 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/resource/v1/resource.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 

--- a/lib/src/sdk/proto/opentelemetry/proto/resource/v1/resource.pbjson.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/resource/v1/resource.pbjson.dart
@@ -1,24 +1,33 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/resource/v1/resource.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
-import 'dart:core' as $core;
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
+
 @$core.Deprecated('Use resourceDescriptor instead')
-const Resource$json = const {
+const Resource$json = {
   '1': 'Resource',
-  '2': const [
-    const {'1': 'attributes', '3': 1, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'attributes'},
-    const {'1': 'dropped_attributes_count', '3': 2, '4': 1, '5': 13, '10': 'droppedAttributesCount'},
+  '2': [
+    {'1': 'attributes', '3': 1, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'attributes'},
+    {'1': 'dropped_attributes_count', '3': 2, '4': 1, '5': 13, '10': 'droppedAttributesCount'},
   ],
 };
 
 /// Descriptor for `Resource`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resourceDescriptor = $convert.base64Decode('CghSZXNvdXJjZRJHCgphdHRyaWJ1dGVzGAEgAygLMicub3BlbnRlbGVtZXRyeS5wcm90by5jb21tb24udjEuS2V5VmFsdWVSCmF0dHJpYnV0ZXMSOAoYZHJvcHBlZF9hdHRyaWJ1dGVzX2NvdW50GAIgASgNUhZkcm9wcGVkQXR0cmlidXRlc0NvdW50');
+final $typed_data.Uint8List resourceDescriptor = $convert.base64Decode(
+    'CghSZXNvdXJjZRJHCgphdHRyaWJ1dGVzGAEgAygLMicub3BlbnRlbGVtZXRyeS5wcm90by5jb2'
+    '1tb24udjEuS2V5VmFsdWVSCmF0dHJpYnV0ZXMSOAoYZHJvcHBlZF9hdHRyaWJ1dGVzX2NvdW50'
+    'GAIgASgNUhZkcm9wcGVkQXR0cmlidXRlc0NvdW50');
+

--- a/lib/src/sdk/proto/opentelemetry/proto/resource/v1/resource.pbserver.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/resource/v1/resource.pbserver.dart
@@ -1,12 +1,17 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/resource/v1/resource.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 export 'resource.pb.dart';
 

--- a/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pb.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pb.dart
@@ -23,19 +23,78 @@ import 'trace.pbenum.dart';
 
 export 'trace.pbenum.dart';
 
-/// A collection of InstrumentationLibrarySpans from a Resource.
+///  TracesData represents the traces data that can be stored in a persistent storage,
+///  OR can be embedded by other protocols that transfer OTLP traces data but do
+///  not implement the OTLP protocol.
+///
+///  The main difference between this message and collector protocol is that
+///  in this message there will not be any "control" or "metadata" specific to
+///  OTLP protocol.
+///
+///  When new fields are added into this message, the OTLP request MUST be updated
+///  as well.
+class TracesData extends $pb.GeneratedMessage {
+  factory TracesData({
+    $core.Iterable<ResourceSpans>? resourceSpans,
+  }) {
+    final $result = create();
+    if (resourceSpans != null) {
+      $result.resourceSpans.addAll(resourceSpans);
+    }
+    return $result;
+  }
+  TracesData._() : super();
+  factory TracesData.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory TracesData.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'TracesData', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
+    ..pc<ResourceSpans>(1, _omitFieldNames ? '' : 'resourceSpans', $pb.PbFieldType.PM, subBuilder: ResourceSpans.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  TracesData clone() => TracesData()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  TracesData copyWith(void Function(TracesData) updates) => super.copyWith((message) => updates(message as TracesData)) as TracesData;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static TracesData create() => TracesData._();
+  TracesData createEmptyInstance() => create();
+  static $pb.PbList<TracesData> createRepeated() => $pb.PbList<TracesData>();
+  @$core.pragma('dart2js:noInline')
+  static TracesData getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<TracesData>(create);
+  static TracesData? _defaultInstance;
+
+  /// An array of ResourceSpans.
+  /// For data coming from a single resource this array will typically contain
+  /// one element. Intermediary nodes that receive data from multiple origins
+  /// typically batch the data before forwarding further and in that case this
+  /// array will contain multiple elements.
+  @$pb.TagNumber(1)
+  $core.List<ResourceSpans> get resourceSpans => $_getList(0);
+}
+
+/// A collection of ScopeSpans from a Resource.
 class ResourceSpans extends $pb.GeneratedMessage {
   factory ResourceSpans({
     $1.Resource? resource,
-    $core.Iterable<InstrumentationLibrarySpans>? instrumentationLibrarySpans,
+    $core.Iterable<ScopeSpans>? scopeSpans,
     $core.String? schemaUrl,
   }) {
     final $result = create();
     if (resource != null) {
       $result.resource = resource;
     }
-    if (instrumentationLibrarySpans != null) {
-      $result.instrumentationLibrarySpans.addAll(instrumentationLibrarySpans);
+    if (scopeSpans != null) {
+      $result.scopeSpans.addAll(scopeSpans);
     }
     if (schemaUrl != null) {
       $result.schemaUrl = schemaUrl;
@@ -48,7 +107,7 @@ class ResourceSpans extends $pb.GeneratedMessage {
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResourceSpans', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
     ..aOM<$1.Resource>(1, _omitFieldNames ? '' : 'resource', subBuilder: $1.Resource.create)
-    ..pc<InstrumentationLibrarySpans>(2, _omitFieldNames ? '' : 'instrumentationLibrarySpans', $pb.PbFieldType.PM, subBuilder: InstrumentationLibrarySpans.create)
+    ..pc<ScopeSpans>(2, _omitFieldNames ? '' : 'scopeSpans', $pb.PbFieldType.PM, subBuilder: ScopeSpans.create)
     ..aOS(3, _omitFieldNames ? '' : 'schemaUrl')
     ..hasRequiredFields = false
   ;
@@ -87,13 +146,15 @@ class ResourceSpans extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $1.Resource ensureResource() => $_ensure(0);
 
-  /// A list of InstrumentationLibrarySpans that originate from a resource.
+  /// A list of ScopeSpans that originate from a resource.
   @$pb.TagNumber(2)
-  $core.List<InstrumentationLibrarySpans> get instrumentationLibrarySpans => $_getList(1);
+  $core.List<ScopeSpans> get scopeSpans => $_getList(1);
 
+  /// The Schema URL, if known. This is the identifier of the Schema that the resource data
+  /// is recorded in. To learn more about Schema URL see
+  /// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   /// This schema_url applies to the data in the "resource" field. It does not apply
-  /// to the data in the "instrumentation_library_spans" field which have their own
-  /// schema_url field.
+  /// to the data in the "scope_spans" field which have their own schema_url field.
   @$pb.TagNumber(3)
   $core.String get schemaUrl => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -104,16 +165,16 @@ class ResourceSpans extends $pb.GeneratedMessage {
   void clearSchemaUrl() => clearField(3);
 }
 
-/// A collection of Spans produced by an InstrumentationLibrary.
-class InstrumentationLibrarySpans extends $pb.GeneratedMessage {
-  factory InstrumentationLibrarySpans({
-    $0.InstrumentationLibrary? instrumentationLibrary,
+/// A collection of Spans produced by an InstrumentationScope.
+class ScopeSpans extends $pb.GeneratedMessage {
+  factory ScopeSpans({
+    $0.InstrumentationScope? scope,
     $core.Iterable<Span>? spans,
     $core.String? schemaUrl,
   }) {
     final $result = create();
-    if (instrumentationLibrary != null) {
-      $result.instrumentationLibrary = instrumentationLibrary;
+    if (scope != null) {
+      $result.scope = scope;
     }
     if (spans != null) {
       $result.spans.addAll(spans);
@@ -123,12 +184,12 @@ class InstrumentationLibrarySpans extends $pb.GeneratedMessage {
     }
     return $result;
   }
-  InstrumentationLibrarySpans._() : super();
-  factory InstrumentationLibrarySpans.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory InstrumentationLibrarySpans.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  ScopeSpans._() : super();
+  factory ScopeSpans.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ScopeSpans.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'InstrumentationLibrarySpans', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
-    ..aOM<$0.InstrumentationLibrary>(1, _omitFieldNames ? '' : 'instrumentationLibrary', subBuilder: $0.InstrumentationLibrary.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ScopeSpans', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
+    ..aOM<$0.InstrumentationScope>(1, _omitFieldNames ? '' : 'scope', subBuilder: $0.InstrumentationScope.create)
     ..pc<Span>(2, _omitFieldNames ? '' : 'spans', $pb.PbFieldType.PM, subBuilder: Span.create)
     ..aOS(3, _omitFieldNames ? '' : 'schemaUrl')
     ..hasRequiredFields = false
@@ -138,41 +199,44 @@ class InstrumentationLibrarySpans extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
   'Will be removed in next major version')
-  InstrumentationLibrarySpans clone() => InstrumentationLibrarySpans()..mergeFromMessage(this);
+  ScopeSpans clone() => ScopeSpans()..mergeFromMessage(this);
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  InstrumentationLibrarySpans copyWith(void Function(InstrumentationLibrarySpans) updates) => super.copyWith((message) => updates(message as InstrumentationLibrarySpans)) as InstrumentationLibrarySpans;
+  ScopeSpans copyWith(void Function(ScopeSpans) updates) => super.copyWith((message) => updates(message as ScopeSpans)) as ScopeSpans;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static InstrumentationLibrarySpans create() => InstrumentationLibrarySpans._();
-  InstrumentationLibrarySpans createEmptyInstance() => create();
-  static $pb.PbList<InstrumentationLibrarySpans> createRepeated() => $pb.PbList<InstrumentationLibrarySpans>();
+  static ScopeSpans create() => ScopeSpans._();
+  ScopeSpans createEmptyInstance() => create();
+  static $pb.PbList<ScopeSpans> createRepeated() => $pb.PbList<ScopeSpans>();
   @$core.pragma('dart2js:noInline')
-  static InstrumentationLibrarySpans getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InstrumentationLibrarySpans>(create);
-  static InstrumentationLibrarySpans? _defaultInstance;
+  static ScopeSpans getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ScopeSpans>(create);
+  static ScopeSpans? _defaultInstance;
 
-  /// The instrumentation library information for the spans in this message.
-  /// Semantically when InstrumentationLibrary isn't set, it is equivalent with
-  /// an empty instrumentation library name (unknown).
+  /// The instrumentation scope information for the spans in this message.
+  /// Semantically when InstrumentationScope isn't set, it is equivalent with
+  /// an empty instrumentation scope name (unknown).
   @$pb.TagNumber(1)
-  $0.InstrumentationLibrary get instrumentationLibrary => $_getN(0);
+  $0.InstrumentationScope get scope => $_getN(0);
   @$pb.TagNumber(1)
-  set instrumentationLibrary($0.InstrumentationLibrary v) { setField(1, v); }
+  set scope($0.InstrumentationScope v) { setField(1, v); }
   @$pb.TagNumber(1)
-  $core.bool hasInstrumentationLibrary() => $_has(0);
+  $core.bool hasScope() => $_has(0);
   @$pb.TagNumber(1)
-  void clearInstrumentationLibrary() => clearField(1);
+  void clearScope() => clearField(1);
   @$pb.TagNumber(1)
-  $0.InstrumentationLibrary ensureInstrumentationLibrary() => $_ensure(0);
+  $0.InstrumentationScope ensureScope() => $_ensure(0);
 
-  /// A list of Spans that originate from an instrumentation library.
+  /// A list of Spans that originate from an instrumentation scope.
   @$pb.TagNumber(2)
   $core.List<Span> get spans => $_getList(1);
 
+  /// The Schema URL, if known. This is the identifier of the Schema that the span data
+  /// is recorded in. To learn more about Schema URL see
+  /// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   /// This schema_url applies to all spans and span events in the "spans" field.
   @$pb.TagNumber(3)
   $core.String get schemaUrl => $_getSZ(2);
@@ -263,6 +327,8 @@ class Span_Event extends $pb.GeneratedMessage {
   void clearName() => clearField(2);
 
   /// attributes is a collection of attribute key/value pairs on the event.
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
   @$pb.TagNumber(3)
   $core.List<$0.KeyValue> get attributes => $_getList(2);
 
@@ -289,6 +355,7 @@ class Span_Link extends $pb.GeneratedMessage {
     $core.String? traceState,
     $core.Iterable<$0.KeyValue>? attributes,
     $core.int? droppedAttributesCount,
+    $core.int? flags,
   }) {
     final $result = create();
     if (traceId != null) {
@@ -306,6 +373,9 @@ class Span_Link extends $pb.GeneratedMessage {
     if (droppedAttributesCount != null) {
       $result.droppedAttributesCount = droppedAttributesCount;
     }
+    if (flags != null) {
+      $result.flags = flags;
+    }
     return $result;
   }
   Span_Link._() : super();
@@ -318,6 +388,7 @@ class Span_Link extends $pb.GeneratedMessage {
     ..aOS(3, _omitFieldNames ? '' : 'traceState')
     ..pc<$0.KeyValue>(4, _omitFieldNames ? '' : 'attributes', $pb.PbFieldType.PM, subBuilder: $0.KeyValue.create)
     ..a<$core.int>(5, _omitFieldNames ? '' : 'droppedAttributesCount', $pb.PbFieldType.OU3)
+    ..a<$core.int>(6, _omitFieldNames ? '' : 'flags', $pb.PbFieldType.OF3)
     ..hasRequiredFields = false
   ;
 
@@ -374,6 +445,8 @@ class Span_Link extends $pb.GeneratedMessage {
   void clearTraceState() => clearField(3);
 
   /// attributes is a collection of attribute key/value pairs on the link.
+  /// Attribute keys MUST be unique (it is not allowed to have more than one
+  /// attribute with the same key).
   @$pb.TagNumber(4)
   $core.List<$0.KeyValue> get attributes => $_getList(3);
 
@@ -387,15 +460,26 @@ class Span_Link extends $pb.GeneratedMessage {
   $core.bool hasDroppedAttributesCount() => $_has(4);
   @$pb.TagNumber(5)
   void clearDroppedAttributesCount() => clearField(5);
+
+  ///  Flags, a bit field. 8 least significant bits are the trace
+  ///  flags as defined in W3C Trace Context specification. Readers
+  ///  MUST not assume that 24 most significant bits will be zero.
+  ///  When creating new spans, the most-significant 24-bits MUST be
+  ///  zero.  To read the 8-bit W3C trace flag (use flags &
+  ///  SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
+  ///
+  ///  See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+  @$pb.TagNumber(6)
+  $core.int get flags => $_getIZ(5);
+  @$pb.TagNumber(6)
+  set flags($core.int v) { $_setUnsignedInt32(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasFlags() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearFlags() => clearField(6);
 }
 
-///  Span represents a single operation within a trace. Spans can be
-///  nested to form a trace tree. Spans may also be linked to other spans
-///  from the same or different trace and form graphs. Often, a trace
-///  contains a root span that describes the end-to-end latency, and one
-///  or more subspans for its sub-operations. A trace can also contain
-///  multiple root spans, or none at all. Spans do not need to be
-///  contiguous - there may be gaps or overlaps between spans in a trace.
+///  A Span represents a single operation performed by a single component of the system.
 ///
 ///  The next available field id is 17.
 class Span extends $pb.GeneratedMessage {
@@ -415,6 +499,7 @@ class Span extends $pb.GeneratedMessage {
     $core.Iterable<Span_Link>? links,
     $core.int? droppedLinksCount,
     Status? status,
+    $core.int? flags,
   }) {
     final $result = create();
     if (traceId != null) {
@@ -462,6 +547,9 @@ class Span extends $pb.GeneratedMessage {
     if (status != null) {
       $result.status = status;
     }
+    if (flags != null) {
+      $result.flags = flags;
+    }
     return $result;
   }
   Span._() : super();
@@ -484,6 +572,7 @@ class Span extends $pb.GeneratedMessage {
     ..pc<Span_Link>(13, _omitFieldNames ? '' : 'links', $pb.PbFieldType.PM, subBuilder: Span_Link.create)
     ..a<$core.int>(14, _omitFieldNames ? '' : 'droppedLinksCount', $pb.PbFieldType.OU3)
     ..aOM<Status>(15, _omitFieldNames ? '' : 'status', subBuilder: Status.create)
+    ..a<$core.int>(16, _omitFieldNames ? '' : 'flags', $pb.PbFieldType.OF3)
     ..hasRequiredFields = false
   ;
 
@@ -509,11 +598,9 @@ class Span extends $pb.GeneratedMessage {
   static Span? _defaultInstance;
 
   ///  A unique identifier for a trace. All spans from the same trace share
-  ///  the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes
-  ///  is considered invalid.
-  ///
-  ///  This field is semantically required. Receiver should generate new
-  ///  random trace_id if empty or invalid trace_id was received.
+  ///  the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
+  ///  of length other than 16 bytes is considered invalid (empty string in OTLP/JSON
+  ///  is zero-length and thus is also invalid).
   ///
   ///  This field is required.
   @$pb.TagNumber(1)
@@ -526,11 +613,9 @@ class Span extends $pb.GeneratedMessage {
   void clearTraceId() => clearField(1);
 
   ///  A unique identifier for a span within a trace, assigned when the span
-  ///  is created. The ID is an 8-byte array. An ID with all zeroes is considered
-  ///  invalid.
-  ///
-  ///  This field is semantically required. Receiver should generate new
-  ///  random span_id if empty or invalid span_id was received.
+  ///  is created. The ID is an 8-byte array. An ID with all zeroes OR of length
+  ///  other than 8 bytes is considered invalid (empty string in OTLP/JSON
+  ///  is zero-length and thus is also invalid).
   ///
   ///  This field is required.
   @$pb.TagNumber(2)
@@ -573,9 +658,7 @@ class Span extends $pb.GeneratedMessage {
   ///  This makes it easier to correlate spans in different traces.
   ///
   ///  This field is semantically required to be set to non-empty string.
-  ///  When null or empty string received - receiver may use string "name"
-  ///  as a replacement. There might be smarted algorithms implemented by
-  ///  receiver to fix the empty span name.
+  ///  Empty value is equivalent to an unknown span name.
   ///
   ///  This field is required.
   @$pb.TagNumber(5)
@@ -629,14 +712,18 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   void clearEndTimeUnixNano() => clearField(8);
 
-  ///  attributes is a collection of key/value pairs. The value can be a string,
-  ///  an integer, a double or the Boolean values `true` or `false`. Note, global attributes
+  ///  attributes is a collection of key/value pairs. Note, global attributes
   ///  like server name can be set using the resource API. Examples of attributes:
   ///
   ///      "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
   ///      "/http/server_latency": 300
-  ///      "abc.com/myattribute": true
-  ///      "abc.com/score": 10.239
+  ///      "example.com/myattribute": true
+  ///      "example.com/score": 10.239
+  ///
+  ///  The OpenTelemetry API specification further restricts the allowed value types:
+  ///  https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
+  ///  Attribute keys MUST be unique (it is not allowed to have more than one
+  ///  attribute with the same key).
   @$pb.TagNumber(9)
   $core.List<$0.KeyValue> get attributes => $_getList(8);
 
@@ -695,22 +782,39 @@ class Span extends $pb.GeneratedMessage {
   void clearStatus() => clearField(15);
   @$pb.TagNumber(15)
   Status ensureStatus() => $_ensure(14);
+
+  ///  Flags, a bit field. 8 least significant bits are the trace
+  ///  flags as defined in W3C Trace Context specification. Readers
+  ///  MUST not assume that 24 most significant bits will be zero.
+  ///  To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+  ///
+  ///  When creating span messages, if the message is logically forwarded from another source
+  ///  with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
+  ///  be copied as-is. If creating from a source that does not have an equivalent flags field
+  ///  (such as a runtime representation of an OpenTelemetry span), the high 24 bits MUST
+  ///  be set to zero.
+  ///
+  ///  [Optional].
+  ///
+  ///  See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+  @$pb.TagNumber(16)
+  $core.int get flags => $_getIZ(15);
+  @$pb.TagNumber(16)
+  set flags($core.int v) { $_setUnsignedInt32(15, v); }
+  @$pb.TagNumber(16)
+  $core.bool hasFlags() => $_has(15);
+  @$pb.TagNumber(16)
+  void clearFlags() => clearField(16);
 }
 
 /// The Status type defines a logical error model that is suitable for different
 /// programming environments, including REST APIs and RPC APIs.
 class Status extends $pb.GeneratedMessage {
   factory Status({
-  @$core.Deprecated('This field is deprecated.')
-    Status_DeprecatedStatusCode? deprecatedCode,
     $core.String? message,
     Status_StatusCode? code,
   }) {
     final $result = create();
-    if (deprecatedCode != null) {
-      // ignore: deprecated_member_use_from_same_package
-      $result.deprecatedCode = deprecatedCode;
-    }
     if (message != null) {
       $result.message = message;
     }
@@ -724,7 +828,6 @@ class Status extends $pb.GeneratedMessage {
   factory Status.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Status', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
-    ..e<Status_DeprecatedStatusCode>(1, _omitFieldNames ? '' : 'deprecatedCode', $pb.PbFieldType.OE, defaultOrMaker: Status_DeprecatedStatusCode.DEPRECATED_STATUS_CODE_OK, valueOf: Status_DeprecatedStatusCode.valueOf, enumValues: Status_DeprecatedStatusCode.values)
     ..aOS(2, _omitFieldNames ? '' : 'message')
     ..e<Status_StatusCode>(3, _omitFieldNames ? '' : 'code', $pb.PbFieldType.OE, defaultOrMaker: Status_StatusCode.STATUS_CODE_UNSET, valueOf: Status_StatusCode.valueOf, enumValues: Status_StatusCode.values)
     ..hasRequiredFields = false
@@ -751,42 +854,23 @@ class Status extends $pb.GeneratedMessage {
   static Status getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Status>(create);
   static Status? _defaultInstance;
 
-  ///  The deprecated status code. This is an optional field.
-  ///
-  ///  This field is deprecated and is replaced by the `code` field below. See backward
-  ///  compatibility notes below. According to our stability guarantees this field
-  ///  will be removed in 12 months, on Oct 22, 2021. All usage of old senders and
-  ///  receivers that do not understand the `code` field MUST be phased out by then.
-  @$core.Deprecated('This field is deprecated.')
-  @$pb.TagNumber(1)
-  Status_DeprecatedStatusCode get deprecatedCode => $_getN(0);
-  @$core.Deprecated('This field is deprecated.')
-  @$pb.TagNumber(1)
-  set deprecatedCode(Status_DeprecatedStatusCode v) { setField(1, v); }
-  @$core.Deprecated('This field is deprecated.')
-  @$pb.TagNumber(1)
-  $core.bool hasDeprecatedCode() => $_has(0);
-  @$core.Deprecated('This field is deprecated.')
-  @$pb.TagNumber(1)
-  void clearDeprecatedCode() => clearField(1);
-
   /// A developer-facing human readable error message.
   @$pb.TagNumber(2)
-  $core.String get message => $_getSZ(1);
+  $core.String get message => $_getSZ(0);
   @$pb.TagNumber(2)
-  set message($core.String v) { $_setString(1, v); }
+  set message($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(2)
-  $core.bool hasMessage() => $_has(1);
+  $core.bool hasMessage() => $_has(0);
   @$pb.TagNumber(2)
   void clearMessage() => clearField(2);
 
   /// The status code.
   @$pb.TagNumber(3)
-  Status_StatusCode get code => $_getN(2);
+  Status_StatusCode get code => $_getN(1);
   @$pb.TagNumber(3)
   set code(Status_StatusCode v) { setField(3, v); }
   @$pb.TagNumber(3)
-  $core.bool hasCode() => $_has(2);
+  $core.bool hasCode() => $_has(1);
   @$pb.TagNumber(3)
   void clearCode() => clearField(3);
 }

--- a/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pb.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pb.dart
@@ -1,53 +1,58 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/trace/v1/trace.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 import 'dart:core' as $core;
 
 import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
-import '../../resource/v1/resource.pb.dart' as $1;
 import '../../common/v1/common.pb.dart' as $0;
-
+import '../../resource/v1/resource.pb.dart' as $1;
 import 'trace.pbenum.dart';
 
 export 'trace.pbenum.dart';
 
+/// A collection of InstrumentationLibrarySpans from a Resource.
 class ResourceSpans extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ResourceSpans', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
-    ..aOM<$1.Resource>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'resource', subBuilder: $1.Resource.create)
-    ..pc<InstrumentationLibrarySpans>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'instrumentationLibrarySpans', $pb.PbFieldType.PM, subBuilder: InstrumentationLibrarySpans.create)
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'schemaUrl')
-    ..hasRequiredFields = false
-  ;
-
-  ResourceSpans._() : super();
   factory ResourceSpans({
     $1.Resource? resource,
     $core.Iterable<InstrumentationLibrarySpans>? instrumentationLibrarySpans,
     $core.String? schemaUrl,
   }) {
-    final _result = create();
+    final $result = create();
     if (resource != null) {
-      _result.resource = resource;
+      $result.resource = resource;
     }
     if (instrumentationLibrarySpans != null) {
-      _result.instrumentationLibrarySpans.addAll(instrumentationLibrarySpans);
+      $result.instrumentationLibrarySpans.addAll(instrumentationLibrarySpans);
     }
     if (schemaUrl != null) {
-      _result.schemaUrl = schemaUrl;
+      $result.schemaUrl = schemaUrl;
     }
-    return _result;
+    return $result;
   }
+  ResourceSpans._() : super();
   factory ResourceSpans.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory ResourceSpans.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ResourceSpans', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
+    ..aOM<$1.Resource>(1, _omitFieldNames ? '' : 'resource', subBuilder: $1.Resource.create)
+    ..pc<InstrumentationLibrarySpans>(2, _omitFieldNames ? '' : 'instrumentationLibrarySpans', $pb.PbFieldType.PM, subBuilder: InstrumentationLibrarySpans.create)
+    ..aOS(3, _omitFieldNames ? '' : 'schemaUrl')
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -57,8 +62,10 @@ class ResourceSpans extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  ResourceSpans copyWith(void Function(ResourceSpans) updates) => super.copyWith((message) => updates(message as ResourceSpans)) as ResourceSpans; // ignore: deprecated_member_use
+  ResourceSpans copyWith(void Function(ResourceSpans) updates) => super.copyWith((message) => updates(message as ResourceSpans)) as ResourceSpans;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static ResourceSpans create() => ResourceSpans._();
   ResourceSpans createEmptyInstance() => create();
@@ -67,6 +74,8 @@ class ResourceSpans extends $pb.GeneratedMessage {
   static ResourceSpans getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ResourceSpans>(create);
   static ResourceSpans? _defaultInstance;
 
+  /// The resource for the spans in this message.
+  /// If this field is not set then no resource info is known.
   @$pb.TagNumber(1)
   $1.Resource get resource => $_getN(0);
   @$pb.TagNumber(1)
@@ -78,9 +87,13 @@ class ResourceSpans extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $1.Resource ensureResource() => $_ensure(0);
 
+  /// A list of InstrumentationLibrarySpans that originate from a resource.
   @$pb.TagNumber(2)
   $core.List<InstrumentationLibrarySpans> get instrumentationLibrarySpans => $_getList(1);
 
+  /// This schema_url applies to the data in the "resource" field. It does not apply
+  /// to the data in the "instrumentation_library_spans" field which have their own
+  /// schema_url field.
   @$pb.TagNumber(3)
   $core.String get schemaUrl => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -91,34 +104,36 @@ class ResourceSpans extends $pb.GeneratedMessage {
   void clearSchemaUrl() => clearField(3);
 }
 
+/// A collection of Spans produced by an InstrumentationLibrary.
 class InstrumentationLibrarySpans extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'InstrumentationLibrarySpans', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
-    ..aOM<$0.InstrumentationLibrary>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'instrumentationLibrary', subBuilder: $0.InstrumentationLibrary.create)
-    ..pc<Span>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'spans', $pb.PbFieldType.PM, subBuilder: Span.create)
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'schemaUrl')
-    ..hasRequiredFields = false
-  ;
-
-  InstrumentationLibrarySpans._() : super();
   factory InstrumentationLibrarySpans({
     $0.InstrumentationLibrary? instrumentationLibrary,
     $core.Iterable<Span>? spans,
     $core.String? schemaUrl,
   }) {
-    final _result = create();
+    final $result = create();
     if (instrumentationLibrary != null) {
-      _result.instrumentationLibrary = instrumentationLibrary;
+      $result.instrumentationLibrary = instrumentationLibrary;
     }
     if (spans != null) {
-      _result.spans.addAll(spans);
+      $result.spans.addAll(spans);
     }
     if (schemaUrl != null) {
-      _result.schemaUrl = schemaUrl;
+      $result.schemaUrl = schemaUrl;
     }
-    return _result;
+    return $result;
   }
+  InstrumentationLibrarySpans._() : super();
   factory InstrumentationLibrarySpans.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory InstrumentationLibrarySpans.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'InstrumentationLibrarySpans', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
+    ..aOM<$0.InstrumentationLibrary>(1, _omitFieldNames ? '' : 'instrumentationLibrary', subBuilder: $0.InstrumentationLibrary.create)
+    ..pc<Span>(2, _omitFieldNames ? '' : 'spans', $pb.PbFieldType.PM, subBuilder: Span.create)
+    ..aOS(3, _omitFieldNames ? '' : 'schemaUrl')
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -128,8 +143,10 @@ class InstrumentationLibrarySpans extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  InstrumentationLibrarySpans copyWith(void Function(InstrumentationLibrarySpans) updates) => super.copyWith((message) => updates(message as InstrumentationLibrarySpans)) as InstrumentationLibrarySpans; // ignore: deprecated_member_use
+  InstrumentationLibrarySpans copyWith(void Function(InstrumentationLibrarySpans) updates) => super.copyWith((message) => updates(message as InstrumentationLibrarySpans)) as InstrumentationLibrarySpans;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static InstrumentationLibrarySpans create() => InstrumentationLibrarySpans._();
   InstrumentationLibrarySpans createEmptyInstance() => create();
@@ -138,6 +155,9 @@ class InstrumentationLibrarySpans extends $pb.GeneratedMessage {
   static InstrumentationLibrarySpans getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<InstrumentationLibrarySpans>(create);
   static InstrumentationLibrarySpans? _defaultInstance;
 
+  /// The instrumentation library information for the spans in this message.
+  /// Semantically when InstrumentationLibrary isn't set, it is equivalent with
+  /// an empty instrumentation library name (unknown).
   @$pb.TagNumber(1)
   $0.InstrumentationLibrary get instrumentationLibrary => $_getN(0);
   @$pb.TagNumber(1)
@@ -149,9 +169,11 @@ class InstrumentationLibrarySpans extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $0.InstrumentationLibrary ensureInstrumentationLibrary() => $_ensure(0);
 
+  /// A list of Spans that originate from an instrumentation library.
   @$pb.TagNumber(2)
   $core.List<Span> get spans => $_getList(1);
 
+  /// This schema_url applies to all spans and span events in the "spans" field.
   @$pb.TagNumber(3)
   $core.String get schemaUrl => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -162,39 +184,42 @@ class InstrumentationLibrarySpans extends $pb.GeneratedMessage {
   void clearSchemaUrl() => clearField(3);
 }
 
+/// Event is a time-stamped annotation of the span, consisting of user-supplied
+/// text description and key-value pairs.
 class Span_Event extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Span.Event', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
-    ..a<$fixnum.Int64>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeUnixNano', $pb.PbFieldType.OF6, defaultOrMaker: $fixnum.Int64.ZERO)
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
-    ..pc<$0.KeyValue>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'attributes', $pb.PbFieldType.PM, subBuilder: $0.KeyValue.create)
-    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'droppedAttributesCount', $pb.PbFieldType.OU3)
-    ..hasRequiredFields = false
-  ;
-
-  Span_Event._() : super();
   factory Span_Event({
     $fixnum.Int64? timeUnixNano,
     $core.String? name,
     $core.Iterable<$0.KeyValue>? attributes,
     $core.int? droppedAttributesCount,
   }) {
-    final _result = create();
+    final $result = create();
     if (timeUnixNano != null) {
-      _result.timeUnixNano = timeUnixNano;
+      $result.timeUnixNano = timeUnixNano;
     }
     if (name != null) {
-      _result.name = name;
+      $result.name = name;
     }
     if (attributes != null) {
-      _result.attributes.addAll(attributes);
+      $result.attributes.addAll(attributes);
     }
     if (droppedAttributesCount != null) {
-      _result.droppedAttributesCount = droppedAttributesCount;
+      $result.droppedAttributesCount = droppedAttributesCount;
     }
-    return _result;
+    return $result;
   }
+  Span_Event._() : super();
   factory Span_Event.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory Span_Event.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Span.Event', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
+    ..a<$fixnum.Int64>(1, _omitFieldNames ? '' : 'timeUnixNano', $pb.PbFieldType.OF6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..aOS(2, _omitFieldNames ? '' : 'name')
+    ..pc<$0.KeyValue>(3, _omitFieldNames ? '' : 'attributes', $pb.PbFieldType.PM, subBuilder: $0.KeyValue.create)
+    ..a<$core.int>(4, _omitFieldNames ? '' : 'droppedAttributesCount', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -204,8 +229,10 @@ class Span_Event extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Span_Event copyWith(void Function(Span_Event) updates) => super.copyWith((message) => updates(message as Span_Event)) as Span_Event; // ignore: deprecated_member_use
+  Span_Event copyWith(void Function(Span_Event) updates) => super.copyWith((message) => updates(message as Span_Event)) as Span_Event;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Span_Event create() => Span_Event._();
   Span_Event createEmptyInstance() => create();
@@ -214,6 +241,7 @@ class Span_Event extends $pb.GeneratedMessage {
   static Span_Event getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Span_Event>(create);
   static Span_Event? _defaultInstance;
 
+  /// time_unix_nano is the time the event occurred.
   @$pb.TagNumber(1)
   $fixnum.Int64 get timeUnixNano => $_getI64(0);
   @$pb.TagNumber(1)
@@ -223,6 +251,8 @@ class Span_Event extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearTimeUnixNano() => clearField(1);
 
+  /// name of the event.
+  /// This field is semantically required to be set to non-empty string.
   @$pb.TagNumber(2)
   $core.String get name => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -232,9 +262,12 @@ class Span_Event extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   void clearName() => clearField(2);
 
+  /// attributes is a collection of attribute key/value pairs on the event.
   @$pb.TagNumber(3)
   $core.List<$0.KeyValue> get attributes => $_getList(2);
 
+  /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
+  /// then no attributes were dropped.
   @$pb.TagNumber(4)
   $core.int get droppedAttributesCount => $_getIZ(3);
   @$pb.TagNumber(4)
@@ -245,17 +278,11 @@ class Span_Event extends $pb.GeneratedMessage {
   void clearDroppedAttributesCount() => clearField(4);
 }
 
+/// A pointer from the current span to another span in the same trace or in a
+/// different trace. For example, this can be used in batching operations,
+/// where a single batch handler processes multiple requests from different
+/// traces or when the handler receives a request from a different project.
 class Span_Link extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Span.Link', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'traceId', $pb.PbFieldType.OY)
-    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'spanId', $pb.PbFieldType.OY)
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'traceState')
-    ..pc<$0.KeyValue>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'attributes', $pb.PbFieldType.PM, subBuilder: $0.KeyValue.create)
-    ..a<$core.int>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'droppedAttributesCount', $pb.PbFieldType.OU3)
-    ..hasRequiredFields = false
-  ;
-
-  Span_Link._() : super();
   factory Span_Link({
     $core.List<$core.int>? traceId,
     $core.List<$core.int>? spanId,
@@ -263,26 +290,37 @@ class Span_Link extends $pb.GeneratedMessage {
     $core.Iterable<$0.KeyValue>? attributes,
     $core.int? droppedAttributesCount,
   }) {
-    final _result = create();
+    final $result = create();
     if (traceId != null) {
-      _result.traceId = traceId;
+      $result.traceId = traceId;
     }
     if (spanId != null) {
-      _result.spanId = spanId;
+      $result.spanId = spanId;
     }
     if (traceState != null) {
-      _result.traceState = traceState;
+      $result.traceState = traceState;
     }
     if (attributes != null) {
-      _result.attributes.addAll(attributes);
+      $result.attributes.addAll(attributes);
     }
     if (droppedAttributesCount != null) {
-      _result.droppedAttributesCount = droppedAttributesCount;
+      $result.droppedAttributesCount = droppedAttributesCount;
     }
-    return _result;
+    return $result;
   }
+  Span_Link._() : super();
   factory Span_Link.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory Span_Link.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Span.Link', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'traceId', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'spanId', $pb.PbFieldType.OY)
+    ..aOS(3, _omitFieldNames ? '' : 'traceState')
+    ..pc<$0.KeyValue>(4, _omitFieldNames ? '' : 'attributes', $pb.PbFieldType.PM, subBuilder: $0.KeyValue.create)
+    ..a<$core.int>(5, _omitFieldNames ? '' : 'droppedAttributesCount', $pb.PbFieldType.OU3)
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -292,8 +330,10 @@ class Span_Link extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Span_Link copyWith(void Function(Span_Link) updates) => super.copyWith((message) => updates(message as Span_Link)) as Span_Link; // ignore: deprecated_member_use
+  Span_Link copyWith(void Function(Span_Link) updates) => super.copyWith((message) => updates(message as Span_Link)) as Span_Link;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Span_Link create() => Span_Link._();
   Span_Link createEmptyInstance() => create();
@@ -302,6 +342,8 @@ class Span_Link extends $pb.GeneratedMessage {
   static Span_Link getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Span_Link>(create);
   static Span_Link? _defaultInstance;
 
+  /// A unique identifier of a trace that this linked span is part of. The ID is a
+  /// 16-byte array.
   @$pb.TagNumber(1)
   $core.List<$core.int> get traceId => $_getN(0);
   @$pb.TagNumber(1)
@@ -311,6 +353,7 @@ class Span_Link extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearTraceId() => clearField(1);
 
+  /// A unique identifier for the linked span. The ID is an 8-byte array.
   @$pb.TagNumber(2)
   $core.List<$core.int> get spanId => $_getN(1);
   @$pb.TagNumber(2)
@@ -320,6 +363,7 @@ class Span_Link extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   void clearSpanId() => clearField(2);
 
+  /// The trace_state associated with the link.
   @$pb.TagNumber(3)
   $core.String get traceState => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -329,9 +373,12 @@ class Span_Link extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   void clearTraceState() => clearField(3);
 
+  /// attributes is a collection of attribute key/value pairs on the link.
   @$pb.TagNumber(4)
   $core.List<$0.KeyValue> get attributes => $_getList(3);
 
+  /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
+  /// then no attributes were dropped.
   @$pb.TagNumber(5)
   $core.int get droppedAttributesCount => $_getIZ(4);
   @$pb.TagNumber(5)
@@ -342,27 +389,16 @@ class Span_Link extends $pb.GeneratedMessage {
   void clearDroppedAttributesCount() => clearField(5);
 }
 
+///  Span represents a single operation within a trace. Spans can be
+///  nested to form a trace tree. Spans may also be linked to other spans
+///  from the same or different trace and form graphs. Often, a trace
+///  contains a root span that describes the end-to-end latency, and one
+///  or more subspans for its sub-operations. A trace can also contain
+///  multiple root spans, or none at all. Spans do not need to be
+///  contiguous - there may be gaps or overlaps between spans in a trace.
+///
+///  The next available field id is 17.
 class Span extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Span', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'traceId', $pb.PbFieldType.OY)
-    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'spanId', $pb.PbFieldType.OY)
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'traceState')
-    ..a<$core.List<$core.int>>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'parentSpanId', $pb.PbFieldType.OY)
-    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
-    ..e<Span_SpanKind>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'kind', $pb.PbFieldType.OE, defaultOrMaker: Span_SpanKind.SPAN_KIND_UNSPECIFIED, valueOf: Span_SpanKind.valueOf, enumValues: Span_SpanKind.values)
-    ..a<$fixnum.Int64>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'startTimeUnixNano', $pb.PbFieldType.OF6, defaultOrMaker: $fixnum.Int64.ZERO)
-    ..a<$fixnum.Int64>(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'endTimeUnixNano', $pb.PbFieldType.OF6, defaultOrMaker: $fixnum.Int64.ZERO)
-    ..pc<$0.KeyValue>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'attributes', $pb.PbFieldType.PM, subBuilder: $0.KeyValue.create)
-    ..a<$core.int>(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'droppedAttributesCount', $pb.PbFieldType.OU3)
-    ..pc<Span_Event>(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'events', $pb.PbFieldType.PM, subBuilder: Span_Event.create)
-    ..a<$core.int>(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'droppedEventsCount', $pb.PbFieldType.OU3)
-    ..pc<Span_Link>(13, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'links', $pb.PbFieldType.PM, subBuilder: Span_Link.create)
-    ..a<$core.int>(14, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'droppedLinksCount', $pb.PbFieldType.OU3)
-    ..aOM<Status>(15, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'status', subBuilder: Status.create)
-    ..hasRequiredFields = false
-  ;
-
-  Span._() : super();
   factory Span({
     $core.List<$core.int>? traceId,
     $core.List<$core.int>? spanId,
@@ -380,56 +416,77 @@ class Span extends $pb.GeneratedMessage {
     $core.int? droppedLinksCount,
     Status? status,
   }) {
-    final _result = create();
+    final $result = create();
     if (traceId != null) {
-      _result.traceId = traceId;
+      $result.traceId = traceId;
     }
     if (spanId != null) {
-      _result.spanId = spanId;
+      $result.spanId = spanId;
     }
     if (traceState != null) {
-      _result.traceState = traceState;
+      $result.traceState = traceState;
     }
     if (parentSpanId != null) {
-      _result.parentSpanId = parentSpanId;
+      $result.parentSpanId = parentSpanId;
     }
     if (name != null) {
-      _result.name = name;
+      $result.name = name;
     }
     if (kind != null) {
-      _result.kind = kind;
+      $result.kind = kind;
     }
     if (startTimeUnixNano != null) {
-      _result.startTimeUnixNano = startTimeUnixNano;
+      $result.startTimeUnixNano = startTimeUnixNano;
     }
     if (endTimeUnixNano != null) {
-      _result.endTimeUnixNano = endTimeUnixNano;
+      $result.endTimeUnixNano = endTimeUnixNano;
     }
     if (attributes != null) {
-      _result.attributes.addAll(attributes);
+      $result.attributes.addAll(attributes);
     }
     if (droppedAttributesCount != null) {
-      _result.droppedAttributesCount = droppedAttributesCount;
+      $result.droppedAttributesCount = droppedAttributesCount;
     }
     if (events != null) {
-      _result.events.addAll(events);
+      $result.events.addAll(events);
     }
     if (droppedEventsCount != null) {
-      _result.droppedEventsCount = droppedEventsCount;
+      $result.droppedEventsCount = droppedEventsCount;
     }
     if (links != null) {
-      _result.links.addAll(links);
+      $result.links.addAll(links);
     }
     if (droppedLinksCount != null) {
-      _result.droppedLinksCount = droppedLinksCount;
+      $result.droppedLinksCount = droppedLinksCount;
     }
     if (status != null) {
-      _result.status = status;
+      $result.status = status;
     }
-    return _result;
+    return $result;
   }
+  Span._() : super();
   factory Span.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory Span.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Span', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, _omitFieldNames ? '' : 'traceId', $pb.PbFieldType.OY)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'spanId', $pb.PbFieldType.OY)
+    ..aOS(3, _omitFieldNames ? '' : 'traceState')
+    ..a<$core.List<$core.int>>(4, _omitFieldNames ? '' : 'parentSpanId', $pb.PbFieldType.OY)
+    ..aOS(5, _omitFieldNames ? '' : 'name')
+    ..e<Span_SpanKind>(6, _omitFieldNames ? '' : 'kind', $pb.PbFieldType.OE, defaultOrMaker: Span_SpanKind.SPAN_KIND_UNSPECIFIED, valueOf: Span_SpanKind.valueOf, enumValues: Span_SpanKind.values)
+    ..a<$fixnum.Int64>(7, _omitFieldNames ? '' : 'startTimeUnixNano', $pb.PbFieldType.OF6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..a<$fixnum.Int64>(8, _omitFieldNames ? '' : 'endTimeUnixNano', $pb.PbFieldType.OF6, defaultOrMaker: $fixnum.Int64.ZERO)
+    ..pc<$0.KeyValue>(9, _omitFieldNames ? '' : 'attributes', $pb.PbFieldType.PM, subBuilder: $0.KeyValue.create)
+    ..a<$core.int>(10, _omitFieldNames ? '' : 'droppedAttributesCount', $pb.PbFieldType.OU3)
+    ..pc<Span_Event>(11, _omitFieldNames ? '' : 'events', $pb.PbFieldType.PM, subBuilder: Span_Event.create)
+    ..a<$core.int>(12, _omitFieldNames ? '' : 'droppedEventsCount', $pb.PbFieldType.OU3)
+    ..pc<Span_Link>(13, _omitFieldNames ? '' : 'links', $pb.PbFieldType.PM, subBuilder: Span_Link.create)
+    ..a<$core.int>(14, _omitFieldNames ? '' : 'droppedLinksCount', $pb.PbFieldType.OU3)
+    ..aOM<Status>(15, _omitFieldNames ? '' : 'status', subBuilder: Status.create)
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -439,8 +496,10 @@ class Span extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Span copyWith(void Function(Span) updates) => super.copyWith((message) => updates(message as Span)) as Span; // ignore: deprecated_member_use
+  Span copyWith(void Function(Span) updates) => super.copyWith((message) => updates(message as Span)) as Span;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Span create() => Span._();
   Span createEmptyInstance() => create();
@@ -449,6 +508,14 @@ class Span extends $pb.GeneratedMessage {
   static Span getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Span>(create);
   static Span? _defaultInstance;
 
+  ///  A unique identifier for a trace. All spans from the same trace share
+  ///  the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes
+  ///  is considered invalid.
+  ///
+  ///  This field is semantically required. Receiver should generate new
+  ///  random trace_id if empty or invalid trace_id was received.
+  ///
+  ///  This field is required.
   @$pb.TagNumber(1)
   $core.List<$core.int> get traceId => $_getN(0);
   @$pb.TagNumber(1)
@@ -458,6 +525,14 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearTraceId() => clearField(1);
 
+  ///  A unique identifier for a span within a trace, assigned when the span
+  ///  is created. The ID is an 8-byte array. An ID with all zeroes is considered
+  ///  invalid.
+  ///
+  ///  This field is semantically required. Receiver should generate new
+  ///  random span_id if empty or invalid span_id was received.
+  ///
+  ///  This field is required.
   @$pb.TagNumber(2)
   $core.List<$core.int> get spanId => $_getN(1);
   @$pb.TagNumber(2)
@@ -467,6 +542,9 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   void clearSpanId() => clearField(2);
 
+  /// trace_state conveys information about request position in multiple distributed tracing graphs.
+  /// It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
+  /// See also https://github.com/w3c/distributed-tracing for more details about this field.
   @$pb.TagNumber(3)
   $core.String get traceState => $_getSZ(2);
   @$pb.TagNumber(3)
@@ -476,6 +554,8 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   void clearTraceState() => clearField(3);
 
+  /// The `span_id` of this span's parent span. If this is a root span, then this
+  /// field must be empty. The ID is an 8-byte array.
   @$pb.TagNumber(4)
   $core.List<$core.int> get parentSpanId => $_getN(3);
   @$pb.TagNumber(4)
@@ -485,6 +565,19 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   void clearParentSpanId() => clearField(4);
 
+  ///  A description of the span's operation.
+  ///
+  ///  For example, the name can be a qualified method name or a file name
+  ///  and a line number where the operation is called. A best practice is to use
+  ///  the same display name at the same call point in an application.
+  ///  This makes it easier to correlate spans in different traces.
+  ///
+  ///  This field is semantically required to be set to non-empty string.
+  ///  When null or empty string received - receiver may use string "name"
+  ///  as a replacement. There might be smarted algorithms implemented by
+  ///  receiver to fix the empty span name.
+  ///
+  ///  This field is required.
   @$pb.TagNumber(5)
   $core.String get name => $_getSZ(4);
   @$pb.TagNumber(5)
@@ -494,6 +587,9 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   void clearName() => clearField(5);
 
+  /// Distinguishes between spans generated in a particular context. For example,
+  /// two spans with the same name may be distinguished using `CLIENT` (caller)
+  /// and `SERVER` (callee) to identify queueing latency associated with the span.
   @$pb.TagNumber(6)
   Span_SpanKind get kind => $_getN(5);
   @$pb.TagNumber(6)
@@ -503,6 +599,12 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   void clearKind() => clearField(6);
 
+  ///  start_time_unix_nano is the start time of the span. On the client side, this is the time
+  ///  kept by the local machine where the span execution starts. On the server side, this
+  ///  is the time when the server's application handler starts running.
+  ///  Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  ///
+  ///  This field is semantically required and it is expected that end_time >= start_time.
   @$pb.TagNumber(7)
   $fixnum.Int64 get startTimeUnixNano => $_getI64(6);
   @$pb.TagNumber(7)
@@ -512,6 +614,12 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   void clearStartTimeUnixNano() => clearField(7);
 
+  ///  end_time_unix_nano is the end time of the span. On the client side, this is the time
+  ///  kept by the local machine where the span execution ends. On the server side, this
+  ///  is the time when the server application handler stops running.
+  ///  Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  ///
+  ///  This field is semantically required and it is expected that end_time >= start_time.
   @$pb.TagNumber(8)
   $fixnum.Int64 get endTimeUnixNano => $_getI64(7);
   @$pb.TagNumber(8)
@@ -521,9 +629,20 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   void clearEndTimeUnixNano() => clearField(8);
 
+  ///  attributes is a collection of key/value pairs. The value can be a string,
+  ///  an integer, a double or the Boolean values `true` or `false`. Note, global attributes
+  ///  like server name can be set using the resource API. Examples of attributes:
+  ///
+  ///      "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
+  ///      "/http/server_latency": 300
+  ///      "abc.com/myattribute": true
+  ///      "abc.com/score": 10.239
   @$pb.TagNumber(9)
   $core.List<$0.KeyValue> get attributes => $_getList(8);
 
+  /// dropped_attributes_count is the number of attributes that were discarded. Attributes
+  /// can be discarded because their keys are too long or because there are too many
+  /// attributes. If this value is 0, then no attributes were dropped.
   @$pb.TagNumber(10)
   $core.int get droppedAttributesCount => $_getIZ(9);
   @$pb.TagNumber(10)
@@ -533,9 +652,12 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   void clearDroppedAttributesCount() => clearField(10);
 
+  /// events is a collection of Event items.
   @$pb.TagNumber(11)
   $core.List<Span_Event> get events => $_getList(10);
 
+  /// dropped_events_count is the number of dropped events. If the value is 0, then no
+  /// events were dropped.
   @$pb.TagNumber(12)
   $core.int get droppedEventsCount => $_getIZ(11);
   @$pb.TagNumber(12)
@@ -545,9 +667,13 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(12)
   void clearDroppedEventsCount() => clearField(12);
 
+  /// links is a collection of Links, which are references from this span to a span
+  /// in the same or different trace.
   @$pb.TagNumber(13)
   $core.List<Span_Link> get links => $_getList(12);
 
+  /// dropped_links_count is the number of dropped links after the maximum size was
+  /// enforced. If this value is 0, then no links were dropped.
   @$pb.TagNumber(14)
   $core.int get droppedLinksCount => $_getIZ(13);
   @$pb.TagNumber(14)
@@ -557,6 +683,8 @@ class Span extends $pb.GeneratedMessage {
   @$pb.TagNumber(14)
   void clearDroppedLinksCount() => clearField(14);
 
+  /// An optional final status for this span. Semantically when Status isn't set, it means
+  /// span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
   @$pb.TagNumber(15)
   Status get status => $_getN(14);
   @$pb.TagNumber(15)
@@ -569,36 +697,39 @@ class Span extends $pb.GeneratedMessage {
   Status ensureStatus() => $_ensure(14);
 }
 
+/// The Status type defines a logical error model that is suitable for different
+/// programming environments, including REST APIs and RPC APIs.
 class Status extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Status', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
-    ..e<Status_DeprecatedStatusCode>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deprecatedCode', $pb.PbFieldType.OE, defaultOrMaker: Status_DeprecatedStatusCode.DEPRECATED_STATUS_CODE_OK, valueOf: Status_DeprecatedStatusCode.valueOf, enumValues: Status_DeprecatedStatusCode.values)
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
-    ..e<Status_StatusCode>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'code', $pb.PbFieldType.OE, defaultOrMaker: Status_StatusCode.STATUS_CODE_UNSET, valueOf: Status_StatusCode.valueOf, enumValues: Status_StatusCode.values)
-    ..hasRequiredFields = false
-  ;
-
-  Status._() : super();
   factory Status({
   @$core.Deprecated('This field is deprecated.')
     Status_DeprecatedStatusCode? deprecatedCode,
     $core.String? message,
     Status_StatusCode? code,
   }) {
-    final _result = create();
+    final $result = create();
     if (deprecatedCode != null) {
       // ignore: deprecated_member_use_from_same_package
-      _result.deprecatedCode = deprecatedCode;
+      $result.deprecatedCode = deprecatedCode;
     }
     if (message != null) {
-      _result.message = message;
+      $result.message = message;
     }
     if (code != null) {
-      _result.code = code;
+      $result.code = code;
     }
-    return _result;
+    return $result;
   }
+  Status._() : super();
   factory Status.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory Status.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Status', package: const $pb.PackageName(_omitMessageNames ? '' : 'opentelemetry.proto.trace.v1'), createEmptyInstance: create)
+    ..e<Status_DeprecatedStatusCode>(1, _omitFieldNames ? '' : 'deprecatedCode', $pb.PbFieldType.OE, defaultOrMaker: Status_DeprecatedStatusCode.DEPRECATED_STATUS_CODE_OK, valueOf: Status_DeprecatedStatusCode.valueOf, enumValues: Status_DeprecatedStatusCode.values)
+    ..aOS(2, _omitFieldNames ? '' : 'message')
+    ..e<Status_StatusCode>(3, _omitFieldNames ? '' : 'code', $pb.PbFieldType.OE, defaultOrMaker: Status_StatusCode.STATUS_CODE_UNSET, valueOf: Status_StatusCode.valueOf, enumValues: Status_StatusCode.values)
+    ..hasRequiredFields = false
+  ;
+
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
@@ -608,8 +739,10 @@ class Status extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Status copyWith(void Function(Status) updates) => super.copyWith((message) => updates(message as Status)) as Status; // ignore: deprecated_member_use
+  Status copyWith(void Function(Status) updates) => super.copyWith((message) => updates(message as Status)) as Status;
+
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static Status create() => Status._();
   Status createEmptyInstance() => create();
@@ -618,6 +751,12 @@ class Status extends $pb.GeneratedMessage {
   static Status getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Status>(create);
   static Status? _defaultInstance;
 
+  ///  The deprecated status code. This is an optional field.
+  ///
+  ///  This field is deprecated and is replaced by the `code` field below. See backward
+  ///  compatibility notes below. According to our stability guarantees this field
+  ///  will be removed in 12 months, on Oct 22, 2021. All usage of old senders and
+  ///  receivers that do not understand the `code` field MUST be phased out by then.
   @$core.Deprecated('This field is deprecated.')
   @$pb.TagNumber(1)
   Status_DeprecatedStatusCode get deprecatedCode => $_getN(0);
@@ -631,6 +770,7 @@ class Status extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   void clearDeprecatedCode() => clearField(1);
 
+  /// A developer-facing human readable error message.
   @$pb.TagNumber(2)
   $core.String get message => $_getSZ(1);
   @$pb.TagNumber(2)
@@ -640,6 +780,7 @@ class Status extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   void clearMessage() => clearField(2);
 
+  /// The status code.
   @$pb.TagNumber(3)
   Status_StatusCode get code => $_getN(2);
   @$pb.TagNumber(3)
@@ -650,3 +791,6 @@ class Status extends $pb.GeneratedMessage {
   void clearCode() => clearField(3);
 }
 
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pbenum.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pbenum.dart
@@ -1,24 +1,30 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/trace/v1/trace.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
-// ignore_for_file: UNDEFINED_SHOWN_NAME
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
 import 'dart:core' as $core;
+
 import 'package:protobuf/protobuf.dart' as $pb;
 
+/// SpanKind is the type of span. Can be used to specify additional relationships between spans
+/// in addition to a parent/child relationship.
 class Span_SpanKind extends $pb.ProtobufEnum {
-  static const Span_SpanKind SPAN_KIND_UNSPECIFIED = Span_SpanKind._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SPAN_KIND_UNSPECIFIED');
-  static const Span_SpanKind SPAN_KIND_INTERNAL = Span_SpanKind._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SPAN_KIND_INTERNAL');
-  static const Span_SpanKind SPAN_KIND_SERVER = Span_SpanKind._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SPAN_KIND_SERVER');
-  static const Span_SpanKind SPAN_KIND_CLIENT = Span_SpanKind._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SPAN_KIND_CLIENT');
-  static const Span_SpanKind SPAN_KIND_PRODUCER = Span_SpanKind._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SPAN_KIND_PRODUCER');
-  static const Span_SpanKind SPAN_KIND_CONSUMER = Span_SpanKind._(5, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'SPAN_KIND_CONSUMER');
+  static const Span_SpanKind SPAN_KIND_UNSPECIFIED = Span_SpanKind._(0, _omitEnumNames ? '' : 'SPAN_KIND_UNSPECIFIED');
+  static const Span_SpanKind SPAN_KIND_INTERNAL = Span_SpanKind._(1, _omitEnumNames ? '' : 'SPAN_KIND_INTERNAL');
+  static const Span_SpanKind SPAN_KIND_SERVER = Span_SpanKind._(2, _omitEnumNames ? '' : 'SPAN_KIND_SERVER');
+  static const Span_SpanKind SPAN_KIND_CLIENT = Span_SpanKind._(3, _omitEnumNames ? '' : 'SPAN_KIND_CLIENT');
+  static const Span_SpanKind SPAN_KIND_PRODUCER = Span_SpanKind._(4, _omitEnumNames ? '' : 'SPAN_KIND_PRODUCER');
+  static const Span_SpanKind SPAN_KIND_CONSUMER = Span_SpanKind._(5, _omitEnumNames ? '' : 'SPAN_KIND_CONSUMER');
 
   static const $core.List<Span_SpanKind> values = <Span_SpanKind> [
     SPAN_KIND_UNSPECIFIED,
@@ -36,23 +42,23 @@ class Span_SpanKind extends $pb.ProtobufEnum {
 }
 
 class Status_DeprecatedStatusCode extends $pb.ProtobufEnum {
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_OK = Status_DeprecatedStatusCode._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_OK');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_CANCELLED = Status_DeprecatedStatusCode._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_CANCELLED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNKNOWN_ERROR = Status_DeprecatedStatusCode._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_UNKNOWN_ERROR');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_INVALID_ARGUMENT = Status_DeprecatedStatusCode._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_INVALID_ARGUMENT');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED = Status_DeprecatedStatusCode._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_NOT_FOUND = Status_DeprecatedStatusCode._(5, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_NOT_FOUND');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_ALREADY_EXISTS = Status_DeprecatedStatusCode._(6, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_ALREADY_EXISTS');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_PERMISSION_DENIED = Status_DeprecatedStatusCode._(7, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_PERMISSION_DENIED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED = Status_DeprecatedStatusCode._(8, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_FAILED_PRECONDITION = Status_DeprecatedStatusCode._(9, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_FAILED_PRECONDITION');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_ABORTED = Status_DeprecatedStatusCode._(10, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_ABORTED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_OUT_OF_RANGE = Status_DeprecatedStatusCode._(11, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_OUT_OF_RANGE');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNIMPLEMENTED = Status_DeprecatedStatusCode._(12, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_UNIMPLEMENTED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_INTERNAL_ERROR = Status_DeprecatedStatusCode._(13, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_INTERNAL_ERROR');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNAVAILABLE = Status_DeprecatedStatusCode._(14, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_UNAVAILABLE');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_DATA_LOSS = Status_DeprecatedStatusCode._(15, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_DATA_LOSS');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNAUTHENTICATED = Status_DeprecatedStatusCode._(16, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'DEPRECATED_STATUS_CODE_UNAUTHENTICATED');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_OK = Status_DeprecatedStatusCode._(0, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_OK');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_CANCELLED = Status_DeprecatedStatusCode._(1, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_CANCELLED');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNKNOWN_ERROR = Status_DeprecatedStatusCode._(2, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_UNKNOWN_ERROR');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_INVALID_ARGUMENT = Status_DeprecatedStatusCode._(3, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_INVALID_ARGUMENT');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED = Status_DeprecatedStatusCode._(4, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_NOT_FOUND = Status_DeprecatedStatusCode._(5, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_NOT_FOUND');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_ALREADY_EXISTS = Status_DeprecatedStatusCode._(6, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_ALREADY_EXISTS');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_PERMISSION_DENIED = Status_DeprecatedStatusCode._(7, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_PERMISSION_DENIED');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED = Status_DeprecatedStatusCode._(8, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_FAILED_PRECONDITION = Status_DeprecatedStatusCode._(9, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_FAILED_PRECONDITION');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_ABORTED = Status_DeprecatedStatusCode._(10, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_ABORTED');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_OUT_OF_RANGE = Status_DeprecatedStatusCode._(11, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_OUT_OF_RANGE');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNIMPLEMENTED = Status_DeprecatedStatusCode._(12, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_UNIMPLEMENTED');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_INTERNAL_ERROR = Status_DeprecatedStatusCode._(13, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_INTERNAL_ERROR');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNAVAILABLE = Status_DeprecatedStatusCode._(14, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_UNAVAILABLE');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_DATA_LOSS = Status_DeprecatedStatusCode._(15, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_DATA_LOSS');
+  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNAUTHENTICATED = Status_DeprecatedStatusCode._(16, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_UNAUTHENTICATED');
 
   static const $core.List<Status_DeprecatedStatusCode> values = <Status_DeprecatedStatusCode> [
     DEPRECATED_STATUS_CODE_OK,
@@ -80,10 +86,12 @@ class Status_DeprecatedStatusCode extends $pb.ProtobufEnum {
   const Status_DeprecatedStatusCode._($core.int v, $core.String n) : super(v, n);
 }
 
+/// For the semantics of status codes see
+/// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
 class Status_StatusCode extends $pb.ProtobufEnum {
-  static const Status_StatusCode STATUS_CODE_UNSET = Status_StatusCode._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'STATUS_CODE_UNSET');
-  static const Status_StatusCode STATUS_CODE_OK = Status_StatusCode._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'STATUS_CODE_OK');
-  static const Status_StatusCode STATUS_CODE_ERROR = Status_StatusCode._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'STATUS_CODE_ERROR');
+  static const Status_StatusCode STATUS_CODE_UNSET = Status_StatusCode._(0, _omitEnumNames ? '' : 'STATUS_CODE_UNSET');
+  static const Status_StatusCode STATUS_CODE_OK = Status_StatusCode._(1, _omitEnumNames ? '' : 'STATUS_CODE_OK');
+  static const Status_StatusCode STATUS_CODE_ERROR = Status_StatusCode._(2, _omitEnumNames ? '' : 'STATUS_CODE_ERROR');
 
   static const $core.List<Status_StatusCode> values = <Status_StatusCode> [
     STATUS_CODE_UNSET,
@@ -97,3 +105,5 @@ class Status_StatusCode extends $pb.ProtobufEnum {
   const Status_StatusCode._($core.int v, $core.String n) : super(v, n);
 }
 
+
+const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pbenum.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pbenum.dart
@@ -16,6 +16,35 @@ import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
+///  SpanFlags represents constants used to interpret the
+///  Span.flags field, which is protobuf 'fixed32' type and is to
+///  be used as bit-fields. Each non-zero value defined in this enum is
+///  a bit-mask.  To extract the bit-field, for example, use an
+///  expression like:
+///
+///    (span.flags & SPAN_FLAGS_TRACE_FLAGS_MASK)
+///
+///  See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+///
+///  Note that Span flags were introduced in version 1.1 of the
+///  OpenTelemetry protocol.  Older Span producers do not set this
+///  field, consequently consumers should not rely on the absence of a
+///  particular flag bit to indicate the presence of a particular feature.
+class SpanFlags extends $pb.ProtobufEnum {
+  static const SpanFlags SPAN_FLAGS_DO_NOT_USE = SpanFlags._(0, _omitEnumNames ? '' : 'SPAN_FLAGS_DO_NOT_USE');
+  static const SpanFlags SPAN_FLAGS_TRACE_FLAGS_MASK = SpanFlags._(255, _omitEnumNames ? '' : 'SPAN_FLAGS_TRACE_FLAGS_MASK');
+
+  static const $core.List<SpanFlags> values = <SpanFlags> [
+    SPAN_FLAGS_DO_NOT_USE,
+    SPAN_FLAGS_TRACE_FLAGS_MASK,
+  ];
+
+  static final $core.Map<$core.int, SpanFlags> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static SpanFlags? valueOf($core.int value) => _byValue[value];
+
+  const SpanFlags._($core.int v, $core.String n) : super(v, n);
+}
+
 /// SpanKind is the type of span. Can be used to specify additional relationships between spans
 /// in addition to a parent/child relationship.
 class Span_SpanKind extends $pb.ProtobufEnum {
@@ -39,51 +68,6 @@ class Span_SpanKind extends $pb.ProtobufEnum {
   static Span_SpanKind? valueOf($core.int value) => _byValue[value];
 
   const Span_SpanKind._($core.int v, $core.String n) : super(v, n);
-}
-
-class Status_DeprecatedStatusCode extends $pb.ProtobufEnum {
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_OK = Status_DeprecatedStatusCode._(0, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_OK');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_CANCELLED = Status_DeprecatedStatusCode._(1, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_CANCELLED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNKNOWN_ERROR = Status_DeprecatedStatusCode._(2, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_UNKNOWN_ERROR');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_INVALID_ARGUMENT = Status_DeprecatedStatusCode._(3, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_INVALID_ARGUMENT');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED = Status_DeprecatedStatusCode._(4, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_NOT_FOUND = Status_DeprecatedStatusCode._(5, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_NOT_FOUND');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_ALREADY_EXISTS = Status_DeprecatedStatusCode._(6, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_ALREADY_EXISTS');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_PERMISSION_DENIED = Status_DeprecatedStatusCode._(7, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_PERMISSION_DENIED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED = Status_DeprecatedStatusCode._(8, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_FAILED_PRECONDITION = Status_DeprecatedStatusCode._(9, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_FAILED_PRECONDITION');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_ABORTED = Status_DeprecatedStatusCode._(10, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_ABORTED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_OUT_OF_RANGE = Status_DeprecatedStatusCode._(11, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_OUT_OF_RANGE');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNIMPLEMENTED = Status_DeprecatedStatusCode._(12, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_UNIMPLEMENTED');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_INTERNAL_ERROR = Status_DeprecatedStatusCode._(13, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_INTERNAL_ERROR');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNAVAILABLE = Status_DeprecatedStatusCode._(14, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_UNAVAILABLE');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_DATA_LOSS = Status_DeprecatedStatusCode._(15, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_DATA_LOSS');
-  static const Status_DeprecatedStatusCode DEPRECATED_STATUS_CODE_UNAUTHENTICATED = Status_DeprecatedStatusCode._(16, _omitEnumNames ? '' : 'DEPRECATED_STATUS_CODE_UNAUTHENTICATED');
-
-  static const $core.List<Status_DeprecatedStatusCode> values = <Status_DeprecatedStatusCode> [
-    DEPRECATED_STATUS_CODE_OK,
-    DEPRECATED_STATUS_CODE_CANCELLED,
-    DEPRECATED_STATUS_CODE_UNKNOWN_ERROR,
-    DEPRECATED_STATUS_CODE_INVALID_ARGUMENT,
-    DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED,
-    DEPRECATED_STATUS_CODE_NOT_FOUND,
-    DEPRECATED_STATUS_CODE_ALREADY_EXISTS,
-    DEPRECATED_STATUS_CODE_PERMISSION_DENIED,
-    DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED,
-    DEPRECATED_STATUS_CODE_FAILED_PRECONDITION,
-    DEPRECATED_STATUS_CODE_ABORTED,
-    DEPRECATED_STATUS_CODE_OUT_OF_RANGE,
-    DEPRECATED_STATUS_CODE_UNIMPLEMENTED,
-    DEPRECATED_STATUS_CODE_INTERNAL_ERROR,
-    DEPRECATED_STATUS_CODE_UNAVAILABLE,
-    DEPRECATED_STATUS_CODE_DATA_LOSS,
-    DEPRECATED_STATUS_CODE_UNAUTHENTICATED,
-  ];
-
-  static final $core.Map<$core.int, Status_DeprecatedStatusCode> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static Status_DeprecatedStatusCode? valueOf($core.int value) => _byValue[value];
-
-  const Status_DeprecatedStatusCode._($core.int v, $core.String n) : super(v, n);
 }
 
 /// For the semantics of status codes see

--- a/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pbjson.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pbjson.dart
@@ -1,154 +1,216 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/trace/v1/trace.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
-import 'dart:core' as $core;
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
+
 @$core.Deprecated('Use resourceSpansDescriptor instead')
-const ResourceSpans$json = const {
+const ResourceSpans$json = {
   '1': 'ResourceSpans',
-  '2': const [
-    const {'1': 'resource', '3': 1, '4': 1, '5': 11, '6': '.opentelemetry.proto.resource.v1.Resource', '10': 'resource'},
-    const {'1': 'instrumentation_library_spans', '3': 2, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans', '10': 'instrumentationLibrarySpans'},
-    const {'1': 'schema_url', '3': 3, '4': 1, '5': 9, '10': 'schemaUrl'},
+  '2': [
+    {'1': 'resource', '3': 1, '4': 1, '5': 11, '6': '.opentelemetry.proto.resource.v1.Resource', '10': 'resource'},
+    {'1': 'instrumentation_library_spans', '3': 2, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans', '10': 'instrumentationLibrarySpans'},
+    {'1': 'schema_url', '3': 3, '4': 1, '5': 9, '10': 'schemaUrl'},
   ],
 };
 
 /// Descriptor for `ResourceSpans`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List resourceSpansDescriptor = $convert.base64Decode('Cg1SZXNvdXJjZVNwYW5zEkUKCHJlc291cmNlGAEgASgLMikub3BlbnRlbGVtZXRyeS5wcm90by5yZXNvdXJjZS52MS5SZXNvdXJjZVIIcmVzb3VyY2USfQodaW5zdHJ1bWVudGF0aW9uX2xpYnJhcnlfc3BhbnMYAiADKAsyOS5vcGVudGVsZW1ldHJ5LnByb3RvLnRyYWNlLnYxLkluc3RydW1lbnRhdGlvbkxpYnJhcnlTcGFuc1IbaW5zdHJ1bWVudGF0aW9uTGlicmFyeVNwYW5zEh0KCnNjaGVtYV91cmwYAyABKAlSCXNjaGVtYVVybA==');
+final $typed_data.Uint8List resourceSpansDescriptor = $convert.base64Decode(
+    'Cg1SZXNvdXJjZVNwYW5zEkUKCHJlc291cmNlGAEgASgLMikub3BlbnRlbGVtZXRyeS5wcm90by'
+    '5yZXNvdXJjZS52MS5SZXNvdXJjZVIIcmVzb3VyY2USfQodaW5zdHJ1bWVudGF0aW9uX2xpYnJh'
+    'cnlfc3BhbnMYAiADKAsyOS5vcGVudGVsZW1ldHJ5LnByb3RvLnRyYWNlLnYxLkluc3RydW1lbn'
+    'RhdGlvbkxpYnJhcnlTcGFuc1IbaW5zdHJ1bWVudGF0aW9uTGlicmFyeVNwYW5zEh0KCnNjaGVt'
+    'YV91cmwYAyABKAlSCXNjaGVtYVVybA==');
+
 @$core.Deprecated('Use instrumentationLibrarySpansDescriptor instead')
-const InstrumentationLibrarySpans$json = const {
+const InstrumentationLibrarySpans$json = {
   '1': 'InstrumentationLibrarySpans',
-  '2': const [
-    const {'1': 'instrumentation_library', '3': 1, '4': 1, '5': 11, '6': '.opentelemetry.proto.common.v1.InstrumentationLibrary', '10': 'instrumentationLibrary'},
-    const {'1': 'spans', '3': 2, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.Span', '10': 'spans'},
-    const {'1': 'schema_url', '3': 3, '4': 1, '5': 9, '10': 'schemaUrl'},
+  '2': [
+    {'1': 'instrumentation_library', '3': 1, '4': 1, '5': 11, '6': '.opentelemetry.proto.common.v1.InstrumentationLibrary', '10': 'instrumentationLibrary'},
+    {'1': 'spans', '3': 2, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.Span', '10': 'spans'},
+    {'1': 'schema_url', '3': 3, '4': 1, '5': 9, '10': 'schemaUrl'},
   ],
 };
 
 /// Descriptor for `InstrumentationLibrarySpans`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List instrumentationLibrarySpansDescriptor = $convert.base64Decode('ChtJbnN0cnVtZW50YXRpb25MaWJyYXJ5U3BhbnMSbgoXaW5zdHJ1bWVudGF0aW9uX2xpYnJhcnkYASABKAsyNS5vcGVudGVsZW1ldHJ5LnByb3RvLmNvbW1vbi52MS5JbnN0cnVtZW50YXRpb25MaWJyYXJ5UhZpbnN0cnVtZW50YXRpb25MaWJyYXJ5EjgKBXNwYW5zGAIgAygLMiIub3BlbnRlbGVtZXRyeS5wcm90by50cmFjZS52MS5TcGFuUgVzcGFucxIdCgpzY2hlbWFfdXJsGAMgASgJUglzY2hlbWFVcmw=');
+final $typed_data.Uint8List instrumentationLibrarySpansDescriptor = $convert.base64Decode(
+    'ChtJbnN0cnVtZW50YXRpb25MaWJyYXJ5U3BhbnMSbgoXaW5zdHJ1bWVudGF0aW9uX2xpYnJhcn'
+    'kYASABKAsyNS5vcGVudGVsZW1ldHJ5LnByb3RvLmNvbW1vbi52MS5JbnN0cnVtZW50YXRpb25M'
+    'aWJyYXJ5UhZpbnN0cnVtZW50YXRpb25MaWJyYXJ5EjgKBXNwYW5zGAIgAygLMiIub3BlbnRlbG'
+    'VtZXRyeS5wcm90by50cmFjZS52MS5TcGFuUgVzcGFucxIdCgpzY2hlbWFfdXJsGAMgASgJUglz'
+    'Y2hlbWFVcmw=');
+
 @$core.Deprecated('Use spanDescriptor instead')
-const Span$json = const {
+const Span$json = {
   '1': 'Span',
-  '2': const [
-    const {'1': 'trace_id', '3': 1, '4': 1, '5': 12, '10': 'traceId'},
-    const {'1': 'span_id', '3': 2, '4': 1, '5': 12, '10': 'spanId'},
-    const {'1': 'trace_state', '3': 3, '4': 1, '5': 9, '10': 'traceState'},
-    const {'1': 'parent_span_id', '3': 4, '4': 1, '5': 12, '10': 'parentSpanId'},
-    const {'1': 'name', '3': 5, '4': 1, '5': 9, '10': 'name'},
-    const {'1': 'kind', '3': 6, '4': 1, '5': 14, '6': '.opentelemetry.proto.trace.v1.Span.SpanKind', '10': 'kind'},
-    const {'1': 'start_time_unix_nano', '3': 7, '4': 1, '5': 6, '10': 'startTimeUnixNano'},
-    const {'1': 'end_time_unix_nano', '3': 8, '4': 1, '5': 6, '10': 'endTimeUnixNano'},
-    const {'1': 'attributes', '3': 9, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'attributes'},
-    const {'1': 'dropped_attributes_count', '3': 10, '4': 1, '5': 13, '10': 'droppedAttributesCount'},
-    const {'1': 'events', '3': 11, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.Span.Event', '10': 'events'},
-    const {'1': 'dropped_events_count', '3': 12, '4': 1, '5': 13, '10': 'droppedEventsCount'},
-    const {'1': 'links', '3': 13, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.Span.Link', '10': 'links'},
-    const {'1': 'dropped_links_count', '3': 14, '4': 1, '5': 13, '10': 'droppedLinksCount'},
-    const {'1': 'status', '3': 15, '4': 1, '5': 11, '6': '.opentelemetry.proto.trace.v1.Status', '10': 'status'},
+  '2': [
+    {'1': 'trace_id', '3': 1, '4': 1, '5': 12, '10': 'traceId'},
+    {'1': 'span_id', '3': 2, '4': 1, '5': 12, '10': 'spanId'},
+    {'1': 'trace_state', '3': 3, '4': 1, '5': 9, '10': 'traceState'},
+    {'1': 'parent_span_id', '3': 4, '4': 1, '5': 12, '10': 'parentSpanId'},
+    {'1': 'name', '3': 5, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'kind', '3': 6, '4': 1, '5': 14, '6': '.opentelemetry.proto.trace.v1.Span.SpanKind', '10': 'kind'},
+    {'1': 'start_time_unix_nano', '3': 7, '4': 1, '5': 6, '10': 'startTimeUnixNano'},
+    {'1': 'end_time_unix_nano', '3': 8, '4': 1, '5': 6, '10': 'endTimeUnixNano'},
+    {'1': 'attributes', '3': 9, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'attributes'},
+    {'1': 'dropped_attributes_count', '3': 10, '4': 1, '5': 13, '10': 'droppedAttributesCount'},
+    {'1': 'events', '3': 11, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.Span.Event', '10': 'events'},
+    {'1': 'dropped_events_count', '3': 12, '4': 1, '5': 13, '10': 'droppedEventsCount'},
+    {'1': 'links', '3': 13, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.Span.Link', '10': 'links'},
+    {'1': 'dropped_links_count', '3': 14, '4': 1, '5': 13, '10': 'droppedLinksCount'},
+    {'1': 'status', '3': 15, '4': 1, '5': 11, '6': '.opentelemetry.proto.trace.v1.Status', '10': 'status'},
   ],
-  '3': const [Span_Event$json, Span_Link$json],
-  '4': const [Span_SpanKind$json],
+  '3': [Span_Event$json, Span_Link$json],
+  '4': [Span_SpanKind$json],
 };
 
 @$core.Deprecated('Use spanDescriptor instead')
-const Span_Event$json = const {
+const Span_Event$json = {
   '1': 'Event',
-  '2': const [
-    const {'1': 'time_unix_nano', '3': 1, '4': 1, '5': 6, '10': 'timeUnixNano'},
-    const {'1': 'name', '3': 2, '4': 1, '5': 9, '10': 'name'},
-    const {'1': 'attributes', '3': 3, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'attributes'},
-    const {'1': 'dropped_attributes_count', '3': 4, '4': 1, '5': 13, '10': 'droppedAttributesCount'},
+  '2': [
+    {'1': 'time_unix_nano', '3': 1, '4': 1, '5': 6, '10': 'timeUnixNano'},
+    {'1': 'name', '3': 2, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'attributes', '3': 3, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'attributes'},
+    {'1': 'dropped_attributes_count', '3': 4, '4': 1, '5': 13, '10': 'droppedAttributesCount'},
   ],
 };
 
 @$core.Deprecated('Use spanDescriptor instead')
-const Span_Link$json = const {
+const Span_Link$json = {
   '1': 'Link',
-  '2': const [
-    const {'1': 'trace_id', '3': 1, '4': 1, '5': 12, '10': 'traceId'},
-    const {'1': 'span_id', '3': 2, '4': 1, '5': 12, '10': 'spanId'},
-    const {'1': 'trace_state', '3': 3, '4': 1, '5': 9, '10': 'traceState'},
-    const {'1': 'attributes', '3': 4, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'attributes'},
-    const {'1': 'dropped_attributes_count', '3': 5, '4': 1, '5': 13, '10': 'droppedAttributesCount'},
+  '2': [
+    {'1': 'trace_id', '3': 1, '4': 1, '5': 12, '10': 'traceId'},
+    {'1': 'span_id', '3': 2, '4': 1, '5': 12, '10': 'spanId'},
+    {'1': 'trace_state', '3': 3, '4': 1, '5': 9, '10': 'traceState'},
+    {'1': 'attributes', '3': 4, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'attributes'},
+    {'1': 'dropped_attributes_count', '3': 5, '4': 1, '5': 13, '10': 'droppedAttributesCount'},
   ],
 };
 
 @$core.Deprecated('Use spanDescriptor instead')
-const Span_SpanKind$json = const {
+const Span_SpanKind$json = {
   '1': 'SpanKind',
-  '2': const [
-    const {'1': 'SPAN_KIND_UNSPECIFIED', '2': 0},
-    const {'1': 'SPAN_KIND_INTERNAL', '2': 1},
-    const {'1': 'SPAN_KIND_SERVER', '2': 2},
-    const {'1': 'SPAN_KIND_CLIENT', '2': 3},
-    const {'1': 'SPAN_KIND_PRODUCER', '2': 4},
-    const {'1': 'SPAN_KIND_CONSUMER', '2': 5},
+  '2': [
+    {'1': 'SPAN_KIND_UNSPECIFIED', '2': 0},
+    {'1': 'SPAN_KIND_INTERNAL', '2': 1},
+    {'1': 'SPAN_KIND_SERVER', '2': 2},
+    {'1': 'SPAN_KIND_CLIENT', '2': 3},
+    {'1': 'SPAN_KIND_PRODUCER', '2': 4},
+    {'1': 'SPAN_KIND_CONSUMER', '2': 5},
   ],
 };
 
 /// Descriptor for `Span`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List spanDescriptor = $convert.base64Decode('CgRTcGFuEhkKCHRyYWNlX2lkGAEgASgMUgd0cmFjZUlkEhcKB3NwYW5faWQYAiABKAxSBnNwYW5JZBIfCgt0cmFjZV9zdGF0ZRgDIAEoCVIKdHJhY2VTdGF0ZRIkCg5wYXJlbnRfc3Bhbl9pZBgEIAEoDFIMcGFyZW50U3BhbklkEhIKBG5hbWUYBSABKAlSBG5hbWUSPwoEa2luZBgGIAEoDjIrLm9wZW50ZWxlbWV0cnkucHJvdG8udHJhY2UudjEuU3Bhbi5TcGFuS2luZFIEa2luZBIvChRzdGFydF90aW1lX3VuaXhfbmFubxgHIAEoBlIRc3RhcnRUaW1lVW5peE5hbm8SKwoSZW5kX3RpbWVfdW5peF9uYW5vGAggASgGUg9lbmRUaW1lVW5peE5hbm8SRwoKYXR0cmlidXRlcxgJIAMoCzInLm9wZW50ZWxlbWV0cnkucHJvdG8uY29tbW9uLnYxLktleVZhbHVlUgphdHRyaWJ1dGVzEjgKGGRyb3BwZWRfYXR0cmlidXRlc19jb3VudBgKIAEoDVIWZHJvcHBlZEF0dHJpYnV0ZXNDb3VudBJACgZldmVudHMYCyADKAsyKC5vcGVudGVsZW1ldHJ5LnByb3RvLnRyYWNlLnYxLlNwYW4uRXZlbnRSBmV2ZW50cxIwChRkcm9wcGVkX2V2ZW50c19jb3VudBgMIAEoDVISZHJvcHBlZEV2ZW50c0NvdW50Ej0KBWxpbmtzGA0gAygLMicub3BlbnRlbGVtZXRyeS5wcm90by50cmFjZS52MS5TcGFuLkxpbmtSBWxpbmtzEi4KE2Ryb3BwZWRfbGlua3NfY291bnQYDiABKA1SEWRyb3BwZWRMaW5rc0NvdW50EjwKBnN0YXR1cxgPIAEoCzIkLm9wZW50ZWxlbWV0cnkucHJvdG8udHJhY2UudjEuU3RhdHVzUgZzdGF0dXMaxAEKBUV2ZW50EiQKDnRpbWVfdW5peF9uYW5vGAEgASgGUgx0aW1lVW5peE5hbm8SEgoEbmFtZRgCIAEoCVIEbmFtZRJHCgphdHRyaWJ1dGVzGAMgAygLMicub3BlbnRlbGVtZXRyeS5wcm90by5jb21tb24udjEuS2V5VmFsdWVSCmF0dHJpYnV0ZXMSOAoYZHJvcHBlZF9hdHRyaWJ1dGVzX2NvdW50GAQgASgNUhZkcm9wcGVkQXR0cmlidXRlc0NvdW50Gt4BCgRMaW5rEhkKCHRyYWNlX2lkGAEgASgMUgd0cmFjZUlkEhcKB3NwYW5faWQYAiABKAxSBnNwYW5JZBIfCgt0cmFjZV9zdGF0ZRgDIAEoCVIKdHJhY2VTdGF0ZRJHCgphdHRyaWJ1dGVzGAQgAygLMicub3BlbnRlbGVtZXRyeS5wcm90by5jb21tb24udjEuS2V5VmFsdWVSCmF0dHJpYnV0ZXMSOAoYZHJvcHBlZF9hdHRyaWJ1dGVzX2NvdW50GAUgASgNUhZkcm9wcGVkQXR0cmlidXRlc0NvdW50IpkBCghTcGFuS2luZBIZChVTUEFOX0tJTkRfVU5TUEVDSUZJRUQQABIWChJTUEFOX0tJTkRfSU5URVJOQUwQARIUChBTUEFOX0tJTkRfU0VSVkVSEAISFAoQU1BBTl9LSU5EX0NMSUVOVBADEhYKElNQQU5fS0lORF9QUk9EVUNFUhAEEhYKElNQQU5fS0lORF9DT05TVU1FUhAF');
+final $typed_data.Uint8List spanDescriptor = $convert.base64Decode(
+    'CgRTcGFuEhkKCHRyYWNlX2lkGAEgASgMUgd0cmFjZUlkEhcKB3NwYW5faWQYAiABKAxSBnNwYW'
+    '5JZBIfCgt0cmFjZV9zdGF0ZRgDIAEoCVIKdHJhY2VTdGF0ZRIkCg5wYXJlbnRfc3Bhbl9pZBgE'
+    'IAEoDFIMcGFyZW50U3BhbklkEhIKBG5hbWUYBSABKAlSBG5hbWUSPwoEa2luZBgGIAEoDjIrLm'
+    '9wZW50ZWxlbWV0cnkucHJvdG8udHJhY2UudjEuU3Bhbi5TcGFuS2luZFIEa2luZBIvChRzdGFy'
+    'dF90aW1lX3VuaXhfbmFubxgHIAEoBlIRc3RhcnRUaW1lVW5peE5hbm8SKwoSZW5kX3RpbWVfdW'
+    '5peF9uYW5vGAggASgGUg9lbmRUaW1lVW5peE5hbm8SRwoKYXR0cmlidXRlcxgJIAMoCzInLm9w'
+    'ZW50ZWxlbWV0cnkucHJvdG8uY29tbW9uLnYxLktleVZhbHVlUgphdHRyaWJ1dGVzEjgKGGRyb3'
+    'BwZWRfYXR0cmlidXRlc19jb3VudBgKIAEoDVIWZHJvcHBlZEF0dHJpYnV0ZXNDb3VudBJACgZl'
+    'dmVudHMYCyADKAsyKC5vcGVudGVsZW1ldHJ5LnByb3RvLnRyYWNlLnYxLlNwYW4uRXZlbnRSBm'
+    'V2ZW50cxIwChRkcm9wcGVkX2V2ZW50c19jb3VudBgMIAEoDVISZHJvcHBlZEV2ZW50c0NvdW50'
+    'Ej0KBWxpbmtzGA0gAygLMicub3BlbnRlbGVtZXRyeS5wcm90by50cmFjZS52MS5TcGFuLkxpbm'
+    'tSBWxpbmtzEi4KE2Ryb3BwZWRfbGlua3NfY291bnQYDiABKA1SEWRyb3BwZWRMaW5rc0NvdW50'
+    'EjwKBnN0YXR1cxgPIAEoCzIkLm9wZW50ZWxlbWV0cnkucHJvdG8udHJhY2UudjEuU3RhdHVzUg'
+    'ZzdGF0dXMaxAEKBUV2ZW50EiQKDnRpbWVfdW5peF9uYW5vGAEgASgGUgx0aW1lVW5peE5hbm8S'
+    'EgoEbmFtZRgCIAEoCVIEbmFtZRJHCgphdHRyaWJ1dGVzGAMgAygLMicub3BlbnRlbGVtZXRyeS'
+    '5wcm90by5jb21tb24udjEuS2V5VmFsdWVSCmF0dHJpYnV0ZXMSOAoYZHJvcHBlZF9hdHRyaWJ1'
+    'dGVzX2NvdW50GAQgASgNUhZkcm9wcGVkQXR0cmlidXRlc0NvdW50Gt4BCgRMaW5rEhkKCHRyYW'
+    'NlX2lkGAEgASgMUgd0cmFjZUlkEhcKB3NwYW5faWQYAiABKAxSBnNwYW5JZBIfCgt0cmFjZV9z'
+    'dGF0ZRgDIAEoCVIKdHJhY2VTdGF0ZRJHCgphdHRyaWJ1dGVzGAQgAygLMicub3BlbnRlbGVtZX'
+    'RyeS5wcm90by5jb21tb24udjEuS2V5VmFsdWVSCmF0dHJpYnV0ZXMSOAoYZHJvcHBlZF9hdHRy'
+    'aWJ1dGVzX2NvdW50GAUgASgNUhZkcm9wcGVkQXR0cmlidXRlc0NvdW50IpkBCghTcGFuS2luZB'
+    'IZChVTUEFOX0tJTkRfVU5TUEVDSUZJRUQQABIWChJTUEFOX0tJTkRfSU5URVJOQUwQARIUChBT'
+    'UEFOX0tJTkRfU0VSVkVSEAISFAoQU1BBTl9LSU5EX0NMSUVOVBADEhYKElNQQU5fS0lORF9QUk'
+    '9EVUNFUhAEEhYKElNQQU5fS0lORF9DT05TVU1FUhAF');
+
 @$core.Deprecated('Use statusDescriptor instead')
-const Status$json = const {
+const Status$json = {
   '1': 'Status',
-  '2': const [
-    const {
+  '2': [
+    {
       '1': 'deprecated_code',
       '3': 1,
       '4': 1,
       '5': 14,
       '6': '.opentelemetry.proto.trace.v1.Status.DeprecatedStatusCode',
-      '8': const {'3': true},
+      '8': {'3': true},
       '10': 'deprecatedCode',
     },
-    const {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
-    const {'1': 'code', '3': 3, '4': 1, '5': 14, '6': '.opentelemetry.proto.trace.v1.Status.StatusCode', '10': 'code'},
+    {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
+    {'1': 'code', '3': 3, '4': 1, '5': 14, '6': '.opentelemetry.proto.trace.v1.Status.StatusCode', '10': 'code'},
   ],
-  '4': const [Status_DeprecatedStatusCode$json, Status_StatusCode$json],
+  '4': [Status_DeprecatedStatusCode$json, Status_StatusCode$json],
 };
 
 @$core.Deprecated('Use statusDescriptor instead')
-const Status_DeprecatedStatusCode$json = const {
+const Status_DeprecatedStatusCode$json = {
   '1': 'DeprecatedStatusCode',
-  '2': const [
-    const {'1': 'DEPRECATED_STATUS_CODE_OK', '2': 0},
-    const {'1': 'DEPRECATED_STATUS_CODE_CANCELLED', '2': 1},
-    const {'1': 'DEPRECATED_STATUS_CODE_UNKNOWN_ERROR', '2': 2},
-    const {'1': 'DEPRECATED_STATUS_CODE_INVALID_ARGUMENT', '2': 3},
-    const {'1': 'DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED', '2': 4},
-    const {'1': 'DEPRECATED_STATUS_CODE_NOT_FOUND', '2': 5},
-    const {'1': 'DEPRECATED_STATUS_CODE_ALREADY_EXISTS', '2': 6},
-    const {'1': 'DEPRECATED_STATUS_CODE_PERMISSION_DENIED', '2': 7},
-    const {'1': 'DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED', '2': 8},
-    const {'1': 'DEPRECATED_STATUS_CODE_FAILED_PRECONDITION', '2': 9},
-    const {'1': 'DEPRECATED_STATUS_CODE_ABORTED', '2': 10},
-    const {'1': 'DEPRECATED_STATUS_CODE_OUT_OF_RANGE', '2': 11},
-    const {'1': 'DEPRECATED_STATUS_CODE_UNIMPLEMENTED', '2': 12},
-    const {'1': 'DEPRECATED_STATUS_CODE_INTERNAL_ERROR', '2': 13},
-    const {'1': 'DEPRECATED_STATUS_CODE_UNAVAILABLE', '2': 14},
-    const {'1': 'DEPRECATED_STATUS_CODE_DATA_LOSS', '2': 15},
-    const {'1': 'DEPRECATED_STATUS_CODE_UNAUTHENTICATED', '2': 16},
+  '2': [
+    {'1': 'DEPRECATED_STATUS_CODE_OK', '2': 0},
+    {'1': 'DEPRECATED_STATUS_CODE_CANCELLED', '2': 1},
+    {'1': 'DEPRECATED_STATUS_CODE_UNKNOWN_ERROR', '2': 2},
+    {'1': 'DEPRECATED_STATUS_CODE_INVALID_ARGUMENT', '2': 3},
+    {'1': 'DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED', '2': 4},
+    {'1': 'DEPRECATED_STATUS_CODE_NOT_FOUND', '2': 5},
+    {'1': 'DEPRECATED_STATUS_CODE_ALREADY_EXISTS', '2': 6},
+    {'1': 'DEPRECATED_STATUS_CODE_PERMISSION_DENIED', '2': 7},
+    {'1': 'DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED', '2': 8},
+    {'1': 'DEPRECATED_STATUS_CODE_FAILED_PRECONDITION', '2': 9},
+    {'1': 'DEPRECATED_STATUS_CODE_ABORTED', '2': 10},
+    {'1': 'DEPRECATED_STATUS_CODE_OUT_OF_RANGE', '2': 11},
+    {'1': 'DEPRECATED_STATUS_CODE_UNIMPLEMENTED', '2': 12},
+    {'1': 'DEPRECATED_STATUS_CODE_INTERNAL_ERROR', '2': 13},
+    {'1': 'DEPRECATED_STATUS_CODE_UNAVAILABLE', '2': 14},
+    {'1': 'DEPRECATED_STATUS_CODE_DATA_LOSS', '2': 15},
+    {'1': 'DEPRECATED_STATUS_CODE_UNAUTHENTICATED', '2': 16},
   ],
 };
 
 @$core.Deprecated('Use statusDescriptor instead')
-const Status_StatusCode$json = const {
+const Status_StatusCode$json = {
   '1': 'StatusCode',
-  '2': const [
-    const {'1': 'STATUS_CODE_UNSET', '2': 0},
-    const {'1': 'STATUS_CODE_OK', '2': 1},
-    const {'1': 'STATUS_CODE_ERROR', '2': 2},
+  '2': [
+    {'1': 'STATUS_CODE_UNSET', '2': 0},
+    {'1': 'STATUS_CODE_OK', '2': 1},
+    {'1': 'STATUS_CODE_ERROR', '2': 2},
   ],
 };
 
 /// Descriptor for `Status`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List statusDescriptor = $convert.base64Decode('CgZTdGF0dXMSZgoPZGVwcmVjYXRlZF9jb2RlGAEgASgOMjkub3BlbnRlbGVtZXRyeS5wcm90by50cmFjZS52MS5TdGF0dXMuRGVwcmVjYXRlZFN0YXR1c0NvZGVCAhgBUg5kZXByZWNhdGVkQ29kZRIYCgdtZXNzYWdlGAIgASgJUgdtZXNzYWdlEkMKBGNvZGUYAyABKA4yLy5vcGVudGVsZW1ldHJ5LnByb3RvLnRyYWNlLnYxLlN0YXR1cy5TdGF0dXNDb2RlUgRjb2RlItoFChREZXByZWNhdGVkU3RhdHVzQ29kZRIdChlERVBSRUNBVEVEX1NUQVRVU19DT0RFX09LEAASJAogREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9DQU5DRUxMRUQQARIoCiRERVBSRUNBVEVEX1NUQVRVU19DT0RFX1VOS05PV05fRVJST1IQAhIrCidERVBSRUNBVEVEX1NUQVRVU19DT0RFX0lOVkFMSURfQVJHVU1FTlQQAxIsCihERVBSRUNBVEVEX1NUQVRVU19DT0RFX0RFQURMSU5FX0VYQ0VFREVEEAQSJAogREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9OT1RfRk9VTkQQBRIpCiVERVBSRUNBVEVEX1NUQVRVU19DT0RFX0FMUkVBRFlfRVhJU1RTEAYSLAooREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9QRVJNSVNTSU9OX0RFTklFRBAHEi0KKURFUFJFQ0FURURfU1RBVFVTX0NPREVfUkVTT1VSQ0VfRVhIQVVTVEVEEAgSLgoqREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9GQUlMRURfUFJFQ09ORElUSU9OEAkSIgoeREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9BQk9SVEVEEAoSJwojREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9PVVRfT0ZfUkFOR0UQCxIoCiRERVBSRUNBVEVEX1NUQVRVU19DT0RFX1VOSU1QTEVNRU5URUQQDBIpCiVERVBSRUNBVEVEX1NUQVRVU19DT0RFX0lOVEVSTkFMX0VSUk9SEA0SJgoiREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9VTkFWQUlMQUJMRRAOEiQKIERFUFJFQ0FURURfU1RBVFVTX0NPREVfREFUQV9MT1NTEA8SKgomREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9VTkFVVEhFTlRJQ0FURUQQECJOCgpTdGF0dXNDb2RlEhUKEVNUQVRVU19DT0RFX1VOU0VUEAASEgoOU1RBVFVTX0NPREVfT0sQARIVChFTVEFUVVNfQ09ERV9FUlJPUhAC');
+final $typed_data.Uint8List statusDescriptor = $convert.base64Decode(
+    'CgZTdGF0dXMSZgoPZGVwcmVjYXRlZF9jb2RlGAEgASgOMjkub3BlbnRlbGVtZXRyeS5wcm90by'
+    '50cmFjZS52MS5TdGF0dXMuRGVwcmVjYXRlZFN0YXR1c0NvZGVCAhgBUg5kZXByZWNhdGVkQ29k'
+    'ZRIYCgdtZXNzYWdlGAIgASgJUgdtZXNzYWdlEkMKBGNvZGUYAyABKA4yLy5vcGVudGVsZW1ldH'
+    'J5LnByb3RvLnRyYWNlLnYxLlN0YXR1cy5TdGF0dXNDb2RlUgRjb2RlItoFChREZXByZWNhdGVk'
+    'U3RhdHVzQ29kZRIdChlERVBSRUNBVEVEX1NUQVRVU19DT0RFX09LEAASJAogREVQUkVDQVRFRF'
+    '9TVEFUVVNfQ09ERV9DQU5DRUxMRUQQARIoCiRERVBSRUNBVEVEX1NUQVRVU19DT0RFX1VOS05P'
+    'V05fRVJST1IQAhIrCidERVBSRUNBVEVEX1NUQVRVU19DT0RFX0lOVkFMSURfQVJHVU1FTlQQAx'
+    'IsCihERVBSRUNBVEVEX1NUQVRVU19DT0RFX0RFQURMSU5FX0VYQ0VFREVEEAQSJAogREVQUkVD'
+    'QVRFRF9TVEFUVVNfQ09ERV9OT1RfRk9VTkQQBRIpCiVERVBSRUNBVEVEX1NUQVRVU19DT0RFX0'
+    'FMUkVBRFlfRVhJU1RTEAYSLAooREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9QRVJNSVNTSU9OX0RF'
+    'TklFRBAHEi0KKURFUFJFQ0FURURfU1RBVFVTX0NPREVfUkVTT1VSQ0VfRVhIQVVTVEVEEAgSLg'
+    'oqREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9GQUlMRURfUFJFQ09ORElUSU9OEAkSIgoeREVQUkVD'
+    'QVRFRF9TVEFUVVNfQ09ERV9BQk9SVEVEEAoSJwojREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9PVV'
+    'RfT0ZfUkFOR0UQCxIoCiRERVBSRUNBVEVEX1NUQVRVU19DT0RFX1VOSU1QTEVNRU5URUQQDBIp'
+    'CiVERVBSRUNBVEVEX1NUQVRVU19DT0RFX0lOVEVSTkFMX0VSUk9SEA0SJgoiREVQUkVDQVRFRF'
+    '9TVEFUVVNfQ09ERV9VTkFWQUlMQUJMRRAOEiQKIERFUFJFQ0FURURfU1RBVFVTX0NPREVfREFU'
+    'QV9MT1NTEA8SKgomREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9VTkFVVEhFTlRJQ0FURUQQECJOCg'
+    'pTdGF0dXNDb2RlEhUKEVNUQVRVU19DT0RFX1VOU0VUEAASEgoOU1RBVFVTX0NPREVfT0sQARIV'
+    'ChFTVEFUVVNfQ09ERV9FUlJPUhAC');
+

--- a/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pbjson.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pbjson.dart
@@ -16,41 +16,69 @@ import 'dart:convert' as $convert;
 import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 
+@$core.Deprecated('Use spanFlagsDescriptor instead')
+const SpanFlags$json = {
+  '1': 'SpanFlags',
+  '2': [
+    {'1': 'SPAN_FLAGS_DO_NOT_USE', '2': 0},
+    {'1': 'SPAN_FLAGS_TRACE_FLAGS_MASK', '2': 255},
+  ],
+};
+
+/// Descriptor for `SpanFlags`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List spanFlagsDescriptor = $convert.base64Decode(
+    'CglTcGFuRmxhZ3MSGQoVU1BBTl9GTEFHU19ET19OT1RfVVNFEAASIAobU1BBTl9GTEFHU19UUk'
+    'FDRV9GTEFHU19NQVNLEP8B');
+
+@$core.Deprecated('Use tracesDataDescriptor instead')
+const TracesData$json = {
+  '1': 'TracesData',
+  '2': [
+    {'1': 'resource_spans', '3': 1, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.ResourceSpans', '10': 'resourceSpans'},
+  ],
+};
+
+/// Descriptor for `TracesData`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List tracesDataDescriptor = $convert.base64Decode(
+    'CgpUcmFjZXNEYXRhElIKDnJlc291cmNlX3NwYW5zGAEgAygLMisub3BlbnRlbGVtZXRyeS5wcm'
+    '90by50cmFjZS52MS5SZXNvdXJjZVNwYW5zUg1yZXNvdXJjZVNwYW5z');
+
 @$core.Deprecated('Use resourceSpansDescriptor instead')
 const ResourceSpans$json = {
   '1': 'ResourceSpans',
   '2': [
     {'1': 'resource', '3': 1, '4': 1, '5': 11, '6': '.opentelemetry.proto.resource.v1.Resource', '10': 'resource'},
-    {'1': 'instrumentation_library_spans', '3': 2, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans', '10': 'instrumentationLibrarySpans'},
+    {'1': 'scope_spans', '3': 2, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.ScopeSpans', '10': 'scopeSpans'},
     {'1': 'schema_url', '3': 3, '4': 1, '5': 9, '10': 'schemaUrl'},
+  ],
+  '9': [
+    {'1': 1000, '2': 1001},
   ],
 };
 
 /// Descriptor for `ResourceSpans`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List resourceSpansDescriptor = $convert.base64Decode(
     'Cg1SZXNvdXJjZVNwYW5zEkUKCHJlc291cmNlGAEgASgLMikub3BlbnRlbGVtZXRyeS5wcm90by'
-    '5yZXNvdXJjZS52MS5SZXNvdXJjZVIIcmVzb3VyY2USfQodaW5zdHJ1bWVudGF0aW9uX2xpYnJh'
-    'cnlfc3BhbnMYAiADKAsyOS5vcGVudGVsZW1ldHJ5LnByb3RvLnRyYWNlLnYxLkluc3RydW1lbn'
-    'RhdGlvbkxpYnJhcnlTcGFuc1IbaW5zdHJ1bWVudGF0aW9uTGlicmFyeVNwYW5zEh0KCnNjaGVt'
-    'YV91cmwYAyABKAlSCXNjaGVtYVVybA==');
+    '5yZXNvdXJjZS52MS5SZXNvdXJjZVIIcmVzb3VyY2USSQoLc2NvcGVfc3BhbnMYAiADKAsyKC5v'
+    'cGVudGVsZW1ldHJ5LnByb3RvLnRyYWNlLnYxLlNjb3BlU3BhbnNSCnNjb3BlU3BhbnMSHQoKc2'
+    'NoZW1hX3VybBgDIAEoCVIJc2NoZW1hVXJsSgYI6AcQ6Qc=');
 
-@$core.Deprecated('Use instrumentationLibrarySpansDescriptor instead')
-const InstrumentationLibrarySpans$json = {
-  '1': 'InstrumentationLibrarySpans',
+@$core.Deprecated('Use scopeSpansDescriptor instead')
+const ScopeSpans$json = {
+  '1': 'ScopeSpans',
   '2': [
-    {'1': 'instrumentation_library', '3': 1, '4': 1, '5': 11, '6': '.opentelemetry.proto.common.v1.InstrumentationLibrary', '10': 'instrumentationLibrary'},
+    {'1': 'scope', '3': 1, '4': 1, '5': 11, '6': '.opentelemetry.proto.common.v1.InstrumentationScope', '10': 'scope'},
     {'1': 'spans', '3': 2, '4': 3, '5': 11, '6': '.opentelemetry.proto.trace.v1.Span', '10': 'spans'},
     {'1': 'schema_url', '3': 3, '4': 1, '5': 9, '10': 'schemaUrl'},
   ],
 };
 
-/// Descriptor for `InstrumentationLibrarySpans`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List instrumentationLibrarySpansDescriptor = $convert.base64Decode(
-    'ChtJbnN0cnVtZW50YXRpb25MaWJyYXJ5U3BhbnMSbgoXaW5zdHJ1bWVudGF0aW9uX2xpYnJhcn'
-    'kYASABKAsyNS5vcGVudGVsZW1ldHJ5LnByb3RvLmNvbW1vbi52MS5JbnN0cnVtZW50YXRpb25M'
-    'aWJyYXJ5UhZpbnN0cnVtZW50YXRpb25MaWJyYXJ5EjgKBXNwYW5zGAIgAygLMiIub3BlbnRlbG'
-    'VtZXRyeS5wcm90by50cmFjZS52MS5TcGFuUgVzcGFucxIdCgpzY2hlbWFfdXJsGAMgASgJUglz'
-    'Y2hlbWFVcmw=');
+/// Descriptor for `ScopeSpans`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List scopeSpansDescriptor = $convert.base64Decode(
+    'CgpTY29wZVNwYW5zEkkKBXNjb3BlGAEgASgLMjMub3BlbnRlbGVtZXRyeS5wcm90by5jb21tb2'
+    '4udjEuSW5zdHJ1bWVudGF0aW9uU2NvcGVSBXNjb3BlEjgKBXNwYW5zGAIgAygLMiIub3BlbnRl'
+    'bGVtZXRyeS5wcm90by50cmFjZS52MS5TcGFuUgVzcGFucxIdCgpzY2hlbWFfdXJsGAMgASgJUg'
+    'lzY2hlbWFVcmw=');
 
 @$core.Deprecated('Use spanDescriptor instead')
 const Span$json = {
@@ -60,6 +88,7 @@ const Span$json = {
     {'1': 'span_id', '3': 2, '4': 1, '5': 12, '10': 'spanId'},
     {'1': 'trace_state', '3': 3, '4': 1, '5': 9, '10': 'traceState'},
     {'1': 'parent_span_id', '3': 4, '4': 1, '5': 12, '10': 'parentSpanId'},
+    {'1': 'flags', '3': 16, '4': 1, '5': 7, '10': 'flags'},
     {'1': 'name', '3': 5, '4': 1, '5': 9, '10': 'name'},
     {'1': 'kind', '3': 6, '4': 1, '5': 14, '6': '.opentelemetry.proto.trace.v1.Span.SpanKind', '10': 'kind'},
     {'1': 'start_time_unix_nano', '3': 7, '4': 1, '5': 6, '10': 'startTimeUnixNano'},
@@ -96,6 +125,7 @@ const Span_Link$json = {
     {'1': 'trace_state', '3': 3, '4': 1, '5': 9, '10': 'traceState'},
     {'1': 'attributes', '3': 4, '4': 3, '5': 11, '6': '.opentelemetry.proto.common.v1.KeyValue', '10': 'attributes'},
     {'1': 'dropped_attributes_count', '3': 5, '4': 1, '5': 13, '10': 'droppedAttributesCount'},
+    {'1': 'flags', '3': 6, '4': 1, '5': 7, '10': 'flags'},
   ],
 };
 
@@ -116,69 +146,40 @@ const Span_SpanKind$json = {
 final $typed_data.Uint8List spanDescriptor = $convert.base64Decode(
     'CgRTcGFuEhkKCHRyYWNlX2lkGAEgASgMUgd0cmFjZUlkEhcKB3NwYW5faWQYAiABKAxSBnNwYW'
     '5JZBIfCgt0cmFjZV9zdGF0ZRgDIAEoCVIKdHJhY2VTdGF0ZRIkCg5wYXJlbnRfc3Bhbl9pZBgE'
-    'IAEoDFIMcGFyZW50U3BhbklkEhIKBG5hbWUYBSABKAlSBG5hbWUSPwoEa2luZBgGIAEoDjIrLm'
-    '9wZW50ZWxlbWV0cnkucHJvdG8udHJhY2UudjEuU3Bhbi5TcGFuS2luZFIEa2luZBIvChRzdGFy'
-    'dF90aW1lX3VuaXhfbmFubxgHIAEoBlIRc3RhcnRUaW1lVW5peE5hbm8SKwoSZW5kX3RpbWVfdW'
-    '5peF9uYW5vGAggASgGUg9lbmRUaW1lVW5peE5hbm8SRwoKYXR0cmlidXRlcxgJIAMoCzInLm9w'
-    'ZW50ZWxlbWV0cnkucHJvdG8uY29tbW9uLnYxLktleVZhbHVlUgphdHRyaWJ1dGVzEjgKGGRyb3'
-    'BwZWRfYXR0cmlidXRlc19jb3VudBgKIAEoDVIWZHJvcHBlZEF0dHJpYnV0ZXNDb3VudBJACgZl'
-    'dmVudHMYCyADKAsyKC5vcGVudGVsZW1ldHJ5LnByb3RvLnRyYWNlLnYxLlNwYW4uRXZlbnRSBm'
-    'V2ZW50cxIwChRkcm9wcGVkX2V2ZW50c19jb3VudBgMIAEoDVISZHJvcHBlZEV2ZW50c0NvdW50'
-    'Ej0KBWxpbmtzGA0gAygLMicub3BlbnRlbGVtZXRyeS5wcm90by50cmFjZS52MS5TcGFuLkxpbm'
-    'tSBWxpbmtzEi4KE2Ryb3BwZWRfbGlua3NfY291bnQYDiABKA1SEWRyb3BwZWRMaW5rc0NvdW50'
-    'EjwKBnN0YXR1cxgPIAEoCzIkLm9wZW50ZWxlbWV0cnkucHJvdG8udHJhY2UudjEuU3RhdHVzUg'
-    'ZzdGF0dXMaxAEKBUV2ZW50EiQKDnRpbWVfdW5peF9uYW5vGAEgASgGUgx0aW1lVW5peE5hbm8S'
-    'EgoEbmFtZRgCIAEoCVIEbmFtZRJHCgphdHRyaWJ1dGVzGAMgAygLMicub3BlbnRlbGVtZXRyeS'
-    '5wcm90by5jb21tb24udjEuS2V5VmFsdWVSCmF0dHJpYnV0ZXMSOAoYZHJvcHBlZF9hdHRyaWJ1'
-    'dGVzX2NvdW50GAQgASgNUhZkcm9wcGVkQXR0cmlidXRlc0NvdW50Gt4BCgRMaW5rEhkKCHRyYW'
-    'NlX2lkGAEgASgMUgd0cmFjZUlkEhcKB3NwYW5faWQYAiABKAxSBnNwYW5JZBIfCgt0cmFjZV9z'
-    'dGF0ZRgDIAEoCVIKdHJhY2VTdGF0ZRJHCgphdHRyaWJ1dGVzGAQgAygLMicub3BlbnRlbGVtZX'
-    'RyeS5wcm90by5jb21tb24udjEuS2V5VmFsdWVSCmF0dHJpYnV0ZXMSOAoYZHJvcHBlZF9hdHRy'
-    'aWJ1dGVzX2NvdW50GAUgASgNUhZkcm9wcGVkQXR0cmlidXRlc0NvdW50IpkBCghTcGFuS2luZB'
-    'IZChVTUEFOX0tJTkRfVU5TUEVDSUZJRUQQABIWChJTUEFOX0tJTkRfSU5URVJOQUwQARIUChBT'
-    'UEFOX0tJTkRfU0VSVkVSEAISFAoQU1BBTl9LSU5EX0NMSUVOVBADEhYKElNQQU5fS0lORF9QUk'
-    '9EVUNFUhAEEhYKElNQQU5fS0lORF9DT05TVU1FUhAF');
+    'IAEoDFIMcGFyZW50U3BhbklkEhQKBWZsYWdzGBAgASgHUgVmbGFncxISCgRuYW1lGAUgASgJUg'
+    'RuYW1lEj8KBGtpbmQYBiABKA4yKy5vcGVudGVsZW1ldHJ5LnByb3RvLnRyYWNlLnYxLlNwYW4u'
+    'U3BhbktpbmRSBGtpbmQSLwoUc3RhcnRfdGltZV91bml4X25hbm8YByABKAZSEXN0YXJ0VGltZV'
+    'VuaXhOYW5vEisKEmVuZF90aW1lX3VuaXhfbmFubxgIIAEoBlIPZW5kVGltZVVuaXhOYW5vEkcK'
+    'CmF0dHJpYnV0ZXMYCSADKAsyJy5vcGVudGVsZW1ldHJ5LnByb3RvLmNvbW1vbi52MS5LZXlWYW'
+    'x1ZVIKYXR0cmlidXRlcxI4Chhkcm9wcGVkX2F0dHJpYnV0ZXNfY291bnQYCiABKA1SFmRyb3Bw'
+    'ZWRBdHRyaWJ1dGVzQ291bnQSQAoGZXZlbnRzGAsgAygLMigub3BlbnRlbGVtZXRyeS5wcm90by'
+    '50cmFjZS52MS5TcGFuLkV2ZW50UgZldmVudHMSMAoUZHJvcHBlZF9ldmVudHNfY291bnQYDCAB'
+    'KA1SEmRyb3BwZWRFdmVudHNDb3VudBI9CgVsaW5rcxgNIAMoCzInLm9wZW50ZWxlbWV0cnkucH'
+    'JvdG8udHJhY2UudjEuU3Bhbi5MaW5rUgVsaW5rcxIuChNkcm9wcGVkX2xpbmtzX2NvdW50GA4g'
+    'ASgNUhFkcm9wcGVkTGlua3NDb3VudBI8CgZzdGF0dXMYDyABKAsyJC5vcGVudGVsZW1ldHJ5Ln'
+    'Byb3RvLnRyYWNlLnYxLlN0YXR1c1IGc3RhdHVzGsQBCgVFdmVudBIkCg50aW1lX3VuaXhfbmFu'
+    'bxgBIAEoBlIMdGltZVVuaXhOYW5vEhIKBG5hbWUYAiABKAlSBG5hbWUSRwoKYXR0cmlidXRlcx'
+    'gDIAMoCzInLm9wZW50ZWxlbWV0cnkucHJvdG8uY29tbW9uLnYxLktleVZhbHVlUgphdHRyaWJ1'
+    'dGVzEjgKGGRyb3BwZWRfYXR0cmlidXRlc19jb3VudBgEIAEoDVIWZHJvcHBlZEF0dHJpYnV0ZX'
+    'NDb3VudBr0AQoETGluaxIZCgh0cmFjZV9pZBgBIAEoDFIHdHJhY2VJZBIXCgdzcGFuX2lkGAIg'
+    'ASgMUgZzcGFuSWQSHwoLdHJhY2Vfc3RhdGUYAyABKAlSCnRyYWNlU3RhdGUSRwoKYXR0cmlidX'
+    'RlcxgEIAMoCzInLm9wZW50ZWxlbWV0cnkucHJvdG8uY29tbW9uLnYxLktleVZhbHVlUgphdHRy'
+    'aWJ1dGVzEjgKGGRyb3BwZWRfYXR0cmlidXRlc19jb3VudBgFIAEoDVIWZHJvcHBlZEF0dHJpYn'
+    'V0ZXNDb3VudBIUCgVmbGFncxgGIAEoB1IFZmxhZ3MimQEKCFNwYW5LaW5kEhkKFVNQQU5fS0lO'
+    'RF9VTlNQRUNJRklFRBAAEhYKElNQQU5fS0lORF9JTlRFUk5BTBABEhQKEFNQQU5fS0lORF9TRV'
+    'JWRVIQAhIUChBTUEFOX0tJTkRfQ0xJRU5UEAMSFgoSU1BBTl9LSU5EX1BST0RVQ0VSEAQSFgoS'
+    'U1BBTl9LSU5EX0NPTlNVTUVSEAU=');
 
 @$core.Deprecated('Use statusDescriptor instead')
 const Status$json = {
   '1': 'Status',
   '2': [
-    {
-      '1': 'deprecated_code',
-      '3': 1,
-      '4': 1,
-      '5': 14,
-      '6': '.opentelemetry.proto.trace.v1.Status.DeprecatedStatusCode',
-      '8': {'3': true},
-      '10': 'deprecatedCode',
-    },
     {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
     {'1': 'code', '3': 3, '4': 1, '5': 14, '6': '.opentelemetry.proto.trace.v1.Status.StatusCode', '10': 'code'},
   ],
-  '4': [Status_DeprecatedStatusCode$json, Status_StatusCode$json],
-};
-
-@$core.Deprecated('Use statusDescriptor instead')
-const Status_DeprecatedStatusCode$json = {
-  '1': 'DeprecatedStatusCode',
-  '2': [
-    {'1': 'DEPRECATED_STATUS_CODE_OK', '2': 0},
-    {'1': 'DEPRECATED_STATUS_CODE_CANCELLED', '2': 1},
-    {'1': 'DEPRECATED_STATUS_CODE_UNKNOWN_ERROR', '2': 2},
-    {'1': 'DEPRECATED_STATUS_CODE_INVALID_ARGUMENT', '2': 3},
-    {'1': 'DEPRECATED_STATUS_CODE_DEADLINE_EXCEEDED', '2': 4},
-    {'1': 'DEPRECATED_STATUS_CODE_NOT_FOUND', '2': 5},
-    {'1': 'DEPRECATED_STATUS_CODE_ALREADY_EXISTS', '2': 6},
-    {'1': 'DEPRECATED_STATUS_CODE_PERMISSION_DENIED', '2': 7},
-    {'1': 'DEPRECATED_STATUS_CODE_RESOURCE_EXHAUSTED', '2': 8},
-    {'1': 'DEPRECATED_STATUS_CODE_FAILED_PRECONDITION', '2': 9},
-    {'1': 'DEPRECATED_STATUS_CODE_ABORTED', '2': 10},
-    {'1': 'DEPRECATED_STATUS_CODE_OUT_OF_RANGE', '2': 11},
-    {'1': 'DEPRECATED_STATUS_CODE_UNIMPLEMENTED', '2': 12},
-    {'1': 'DEPRECATED_STATUS_CODE_INTERNAL_ERROR', '2': 13},
-    {'1': 'DEPRECATED_STATUS_CODE_UNAVAILABLE', '2': 14},
-    {'1': 'DEPRECATED_STATUS_CODE_DATA_LOSS', '2': 15},
-    {'1': 'DEPRECATED_STATUS_CODE_UNAUTHENTICATED', '2': 16},
+  '4': [Status_StatusCode$json],
+  '9': [
+    {'1': 1, '2': 2},
   ],
 };
 
@@ -194,23 +195,8 @@ const Status_StatusCode$json = {
 
 /// Descriptor for `Status`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List statusDescriptor = $convert.base64Decode(
-    'CgZTdGF0dXMSZgoPZGVwcmVjYXRlZF9jb2RlGAEgASgOMjkub3BlbnRlbGVtZXRyeS5wcm90by'
-    '50cmFjZS52MS5TdGF0dXMuRGVwcmVjYXRlZFN0YXR1c0NvZGVCAhgBUg5kZXByZWNhdGVkQ29k'
-    'ZRIYCgdtZXNzYWdlGAIgASgJUgdtZXNzYWdlEkMKBGNvZGUYAyABKA4yLy5vcGVudGVsZW1ldH'
-    'J5LnByb3RvLnRyYWNlLnYxLlN0YXR1cy5TdGF0dXNDb2RlUgRjb2RlItoFChREZXByZWNhdGVk'
-    'U3RhdHVzQ29kZRIdChlERVBSRUNBVEVEX1NUQVRVU19DT0RFX09LEAASJAogREVQUkVDQVRFRF'
-    '9TVEFUVVNfQ09ERV9DQU5DRUxMRUQQARIoCiRERVBSRUNBVEVEX1NUQVRVU19DT0RFX1VOS05P'
-    'V05fRVJST1IQAhIrCidERVBSRUNBVEVEX1NUQVRVU19DT0RFX0lOVkFMSURfQVJHVU1FTlQQAx'
-    'IsCihERVBSRUNBVEVEX1NUQVRVU19DT0RFX0RFQURMSU5FX0VYQ0VFREVEEAQSJAogREVQUkVD'
-    'QVRFRF9TVEFUVVNfQ09ERV9OT1RfRk9VTkQQBRIpCiVERVBSRUNBVEVEX1NUQVRVU19DT0RFX0'
-    'FMUkVBRFlfRVhJU1RTEAYSLAooREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9QRVJNSVNTSU9OX0RF'
-    'TklFRBAHEi0KKURFUFJFQ0FURURfU1RBVFVTX0NPREVfUkVTT1VSQ0VfRVhIQVVTVEVEEAgSLg'
-    'oqREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9GQUlMRURfUFJFQ09ORElUSU9OEAkSIgoeREVQUkVD'
-    'QVRFRF9TVEFUVVNfQ09ERV9BQk9SVEVEEAoSJwojREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9PVV'
-    'RfT0ZfUkFOR0UQCxIoCiRERVBSRUNBVEVEX1NUQVRVU19DT0RFX1VOSU1QTEVNRU5URUQQDBIp'
-    'CiVERVBSRUNBVEVEX1NUQVRVU19DT0RFX0lOVEVSTkFMX0VSUk9SEA0SJgoiREVQUkVDQVRFRF'
-    '9TVEFUVVNfQ09ERV9VTkFWQUlMQUJMRRAOEiQKIERFUFJFQ0FURURfU1RBVFVTX0NPREVfREFU'
-    'QV9MT1NTEA8SKgomREVQUkVDQVRFRF9TVEFUVVNfQ09ERV9VTkFVVEhFTlRJQ0FURUQQECJOCg'
-    'pTdGF0dXNDb2RlEhUKEVNUQVRVU19DT0RFX1VOU0VUEAASEgoOU1RBVFVTX0NPREVfT0sQARIV'
-    'ChFTVEFUVVNfQ09ERV9FUlJPUhAC');
+    'CgZTdGF0dXMSGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZRJDCgRjb2RlGAMgASgOMi8ub3Blbn'
+    'RlbGVtZXRyeS5wcm90by50cmFjZS52MS5TdGF0dXMuU3RhdHVzQ29kZVIEY29kZSJOCgpTdGF0'
+    'dXNDb2RlEhUKEVNUQVRVU19DT0RFX1VOU0VUEAASEgoOU1RBVFVTX0NPREVfT0sQARIVChFTVE'
+    'FUVVNfQ09ERV9FUlJPUhACSgQIARAC');
 

--- a/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pbserver.dart
+++ b/lib/src/sdk/proto/opentelemetry/proto/trace/v1/trace.pbserver.dart
@@ -1,12 +1,17 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-///
+//
 //  Generated code. Do not modify.
 //  source: opentelemetry/proto/trace/v1/trace.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
 
 export 'trace.pb.dart';
 

--- a/lib/src/sdk/trace/exporters/collector_exporter.dart
+++ b/lib/src/sdk/trace/exporters/collector_exporter.dart
@@ -46,17 +46,17 @@ class CollectorExporter implements sdk.SpanExporter {
 
   /// Group and construct the protobuf equivalent of the given list of [api.Span]s.
   /// Spans are grouped by a trace provider's [sdk.Resource] and a tracer's
-  /// [api.InstrumentationLibrary].
+  /// [sdk.InstrumentationScope].
   Iterable<pb_trace.ResourceSpans> _spansToProtobuf(
       List<sdk.ReadOnlySpan> spans) {
     // use a map of maps to group spans by resource and instrumentation library
     final rsm =
-        <sdk.Resource, Map<api.InstrumentationLibrary, List<pb_trace.Span>>>{};
+        <sdk.Resource, Map<sdk.InstrumentationScope, List<pb_trace.Span>>>{};
     for (final span in spans) {
       final il = rsm[span.resource] ??
-          <api.InstrumentationLibrary, List<pb_trace.Span>>{};
-      il[span.instrumentationLibrary] =
-          il[span.instrumentationLibrary] ?? <pb_trace.Span>[]
+          <sdk.InstrumentationScope, List<pb_trace.Span>>{};
+      il[span.instrumentationScope] =
+          il[span.instrumentationScope] ?? <pb_trace.Span>[]
             ..add(_spanToProtobuf(span));
       rsm[span.resource] = il;
     }

--- a/lib/src/sdk/trace/exporters/collector_exporter.dart
+++ b/lib/src/sdk/trace/exporters/collector_exporter.dart
@@ -71,13 +71,12 @@ class CollectorExporter implements sdk.SpanExporter {
             value: _attributeValueToProtobuf(il.key.attributes.get(attr))));
       }
       final rs = pb_trace.ResourceSpans(
-          resource: pb_resource.Resource(attributes: attrs),
-          instrumentationLibrarySpans: []);
+          resource: pb_resource.Resource(attributes: attrs), scopeSpans: []);
       // for each distinct instrumentation library, construct the protobuf equivalent
       for (final ils in il.value.entries) {
-        rs.instrumentationLibrarySpans.add(pb_trace.InstrumentationLibrarySpans(
+        rs.scopeSpans.add(pb_trace.ScopeSpans(
             spans: ils.value,
-            instrumentationLibrary: pb_common.InstrumentationLibrary(
+            scope: pb_common.InstrumentationScope(
                 name: ils.key.name, version: ils.key.version)));
       }
       rss.add(rs);

--- a/lib/src/sdk/trace/read_only_span.dart
+++ b/lib/src/sdk/trace/read_only_span.dart
@@ -40,7 +40,7 @@ abstract class ReadOnlySpan {
   // TODO: O11Y-1531: SpanEvents here.
 
   /// The instrumentation library for the span.
-  api.InstrumentationLibrary get instrumentationLibrary;
+  sdk.InstrumentationScope get instrumentationScope;
 
   List<api.SpanLink> get links;
 

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -19,7 +19,7 @@ class Span implements sdk.ReadWriteSpan {
   final sdk.TimeProvider _timeProvider;
   final sdk.Resource _resource;
   final sdk.SpanLimits _limits;
-  final api.InstrumentationLibrary _instrumentationLibrary;
+  final sdk.InstrumentationScope _instrumentationScope;
   final Int64 _startTime;
   final Attributes _attributes = Attributes.empty();
   String _name;
@@ -45,7 +45,7 @@ class Span implements sdk.ReadWriteSpan {
       this._processors,
       this._timeProvider,
       this._resource,
-      this._instrumentationLibrary,
+      this._instrumentationScope,
       api.SpanKind kind,
       List<api.Attribute> attributes,
       List<api.SpanLink> links,
@@ -109,8 +109,7 @@ class Span implements sdk.ReadWriteSpan {
   sdk.Resource get resource => _resource;
 
   @override
-  api.InstrumentationLibrary get instrumentationLibrary =>
-      _instrumentationLibrary;
+  sdk.InstrumentationScope get instrumentationScope => _instrumentationScope;
 
   @override
   void setAttributes(List<api.Attribute> attributes) {

--- a/lib/src/sdk/trace/tracer.dart
+++ b/lib/src/sdk/trace/tracer.dart
@@ -15,7 +15,7 @@ class Tracer implements api.Tracer {
   final sdk.Sampler _sampler;
   final sdk.TimeProvider _timeProvider;
   final api.IdGenerator _idGenerator;
-  final api.InstrumentationLibrary _instrumentationLibrary;
+  final sdk.InstrumentationScope _instrumentationScope;
   final sdk.SpanLimits _spanLimits;
 
   @protected
@@ -25,7 +25,7 @@ class Tracer implements api.Tracer {
       this._sampler,
       this._timeProvider,
       this._idGenerator,
-      this._instrumentationLibrary,
+      this._instrumentationScope,
       this._spanLimits);
 
   @override
@@ -71,7 +71,7 @@ class Tracer implements api.Tracer {
         _processors,
         _timeProvider,
         _resource,
-        _instrumentationLibrary,
+        _instrumentationScope,
         kind,
         attributes,
         links,

--- a/lib/src/sdk/trace/tracer_provider.dart
+++ b/lib/src/sdk/trace/tracer_provider.dart
@@ -42,7 +42,10 @@ class TracerProviderBase implements api.TracerProvider {
   List<sdk.SpanProcessor> get spanProcessors => processors;
 
   @override
-  api.Tracer getTracer(String name, {String version = ''}) {
+  api.Tracer getTracer(String name,
+      {String version = '',
+      String schemaUrl = '',
+      List<api.Attribute> attributes = const []}) {
     final key = '$name@$version';
     return tracers.putIfAbsent(
         key,
@@ -52,7 +55,7 @@ class TracerProviderBase implements api.TracerProvider {
             sampler,
             sdk.DateTimeTimeProvider(),
             idGenerator,
-            sdk.InstrumentationLibrary(name, version),
+            sdk.InstrumentationScope(name, version, schemaUrl, attributes),
             spanLimits));
   }
 

--- a/test/integration/api/propagation/w3c_trace_context_propagator_test.dart
+++ b/test/integration/api/propagation/w3c_trace_context_propagator_test.dart
@@ -4,7 +4,6 @@
 @TestOn('vm')
 import 'package:opentelemetry/api.dart' as api;
 import 'package:opentelemetry/sdk.dart' as sdk;
-import 'package:opentelemetry/src/api/trace/nonrecording_span.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:test/test.dart';
 
@@ -43,7 +42,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.client,
         [],
         [],
@@ -83,7 +83,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.client,
         [],
         [],
@@ -123,7 +124,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.client,
         [],
         [],

--- a/test/integration/open_telemetry_test.dart
+++ b/test/integration/open_telemetry_test.dart
@@ -17,7 +17,7 @@ void main() {
         sdk.AlwaysOnSampler(),
         sdk.DateTimeTimeProvider(),
         sdk.IdGenerator(),
-        sdk.InstrumentationLibrary('name', 'version'),
+        sdk.InstrumentationScope('name', 'version', 'url://schema', []),
         sdk.SpanLimits());
     Span span;
 
@@ -37,7 +37,7 @@ void main() {
         sdk.AlwaysOnSampler(),
         sdk.DateTimeTimeProvider(),
         sdk.IdGenerator(),
-        sdk.InstrumentationLibrary('name', 'version'),
+        sdk.InstrumentationScope('name', 'version', 'url://schema', []),
         sdk.SpanLimits());
     final spans = <Span>[];
 
@@ -59,7 +59,7 @@ void main() {
         sdk.AlwaysOnSampler(),
         sdk.DateTimeTimeProvider(),
         sdk.IdGenerator(),
-        sdk.InstrumentationLibrary('name', 'version'),
+        sdk.InstrumentationScope('name', 'version', 'url://schema', []),
         sdk.SpanLimits());
     Span span;
 
@@ -84,7 +84,7 @@ void main() {
         sdk.AlwaysOnSampler(),
         sdk.DateTimeTimeProvider(),
         sdk.IdGenerator(),
-        sdk.InstrumentationLibrary('name', 'version'),
+        sdk.InstrumentationScope('name', 'version', 'url://schema', []),
         sdk.SpanLimits());
     Span span;
 
@@ -104,7 +104,7 @@ void main() {
         sdk.AlwaysOnSampler(),
         sdk.DateTimeTimeProvider(),
         sdk.IdGenerator(),
-        sdk.InstrumentationLibrary('name', 'version'),
+        sdk.InstrumentationScope('name', 'version', 'url://schema', []),
         sdk.SpanLimits());
     final spans = <Span>[];
 
@@ -126,7 +126,7 @@ void main() {
         sdk.AlwaysOnSampler(),
         sdk.DateTimeTimeProvider(),
         sdk.IdGenerator(),
-        sdk.InstrumentationLibrary('name', 'version'),
+        sdk.InstrumentationScope('name', 'version', 'url://schema', []),
         sdk.SpanLimits());
     Span span;
 
@@ -153,7 +153,7 @@ void main() {
         sdk.AlwaysOnSampler(),
         sdk.DateTimeTimeProvider(),
         sdk.IdGenerator(),
-        sdk.InstrumentationLibrary('name', 'version'),
+        sdk.InstrumentationScope('name', 'version', 'url://schema', []),
         sdk.SpanLimits());
     Span span;
 

--- a/test/integration/sdk/span_test.dart
+++ b/test/integration/sdk/span_test.dart
@@ -24,7 +24,8 @@ void main() {
         [mockProcessor1, mockProcessor2],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -60,7 +61,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.client,
         [],
         [],
@@ -129,7 +131,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.client,
         [],
         [],
@@ -159,7 +162,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.client,
         [],
         [],

--- a/test/integration/sdk/tracer_test.dart
+++ b/test/integration/sdk/tracer_test.dart
@@ -10,12 +10,14 @@ import 'package:test/test.dart';
 
 void main() {
   test('startSpan new trace', () {
-    final tracer = Tracer([],
+    final tracer = Tracer(
+        [],
         sdk.Resource([]),
         sdk.AlwaysOnSampler(),
         sdk.DateTimeTimeProvider(),
         sdk.IdGenerator(),
-        sdk.InstrumentationLibrary('name', 'version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         sdk.SpanLimits());
 
     final span = tracer.startSpan('foo') as Span;
@@ -27,12 +29,14 @@ void main() {
   });
 
   test('startSpan child span', () {
-    final tracer = Tracer([],
+    final tracer = Tracer(
+        [],
         sdk.Resource([]),
         sdk.AlwaysOnSampler(),
         sdk.DateTimeTimeProvider(),
         sdk.IdGenerator(),
-        sdk.InstrumentationLibrary('name', 'version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         sdk.SpanLimits());
 
     final parentSpan = tracer.startSpan('foo');

--- a/test/unit/api/context_test.dart
+++ b/test/unit/api/context_test.dart
@@ -17,7 +17,8 @@ void main() {
       [],
       sdk.DateTimeTimeProvider(),
       sdk.Resource([]),
-      sdk.InstrumentationLibrary('library_name', 'library_version'),
+      sdk.InstrumentationScope(
+          'library_name', 'library_version', 'url://schema', []),
       api.SpanKind.client,
       [],
       [],

--- a/test/unit/api/propagation/w3c_trace_context_propagator_test.dart
+++ b/test/unit/api/propagation/w3c_trace_context_propagator_test.dart
@@ -4,8 +4,6 @@
 @TestOn('vm')
 import 'package:opentelemetry/api.dart' as api;
 import 'package:opentelemetry/sdk.dart' as sdk;
-import 'package:opentelemetry/src/api/trace/nonrecording_span.dart';
-import 'package:opentelemetry/src/sdk/instrumentation_library.dart';
 import 'package:opentelemetry/src/sdk/resource/resource.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:test/test.dart';
@@ -149,7 +147,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.client,
         [],
         [],
@@ -181,7 +180,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.client,
         [],
         [],

--- a/test/unit/sdk/exporters/collector_exporter_test.dart
+++ b/test/unit/sdk/exporters/collector_exporter_test.dart
@@ -85,8 +85,8 @@ void main() {
                 key: 'service.name',
                 value: pb_common.AnyValue(stringValue: 'bar'))
           ]),
-          instrumentationLibrarySpans: [
-            pb.InstrumentationLibrarySpans(
+          scopeSpans: [
+            pb.ScopeSpans(
                 spans: [
                   pb.Span(
                       traceId: [1, 2, 3],
@@ -133,7 +133,7 @@ void main() {
                             ])
                       ])
                 ],
-                instrumentationLibrary: pb_common.InstrumentationLibrary(
+                scope: pb_common.InstrumentationScope(
                     name: 'library_name', version: 'library_version'))
           ])
     ]);

--- a/test/unit/sdk/exporters/collector_exporter_test.dart
+++ b/test/unit/sdk/exporters/collector_exporter_test.dart
@@ -34,8 +34,8 @@ void main() {
   test('sends spans', () {
     final resource =
         sdk.Resource([api.Attribute.fromString('service.name', 'bar')]);
-    final instrumentationLibrary =
-        sdk.InstrumentationLibrary('library_name', 'library_version');
+    final instrumentationLibrary = sdk.InstrumentationScope(
+        'library_name', 'library_version', 'url://schema', []);
     final limits = sdk.SpanLimits(maxNumAttributeLength: 5);
     final span1 = Span(
         'foo',
@@ -152,7 +152,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -179,7 +180,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -213,7 +215,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],

--- a/test/unit/sdk/exporters/console_exporter_test.dart
+++ b/test/unit/sdk/exporters/console_exporter_test.dart
@@ -33,7 +33,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -59,7 +60,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],

--- a/test/unit/sdk/platforms/web/web_time_provider_test.dart
+++ b/test/unit/sdk/platforms/web/web_time_provider_test.dart
@@ -18,7 +18,8 @@ void main() {
         [],
         WebTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],

--- a/test/unit/sdk/sampling/always_off_sampler_test.dart
+++ b/test/unit/sdk/sampling/always_off_sampler_test.dart
@@ -19,7 +19,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -49,7 +50,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         attributesList,
         [],

--- a/test/unit/sdk/sampling/always_on_sampler_test.dart
+++ b/test/unit/sdk/sampling/always_on_sampler_test.dart
@@ -19,7 +19,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -45,7 +46,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],

--- a/test/unit/sdk/sampling/parent_based_sampler_test.dart
+++ b/test/unit/sdk/sampling/parent_based_sampler_test.dart
@@ -25,7 +25,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -51,7 +52,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -78,7 +80,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -106,7 +109,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -134,7 +138,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -162,7 +167,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],

--- a/test/unit/sdk/span_limits_test.dart
+++ b/test/unit/sdk/span_limits_test.dart
@@ -57,7 +57,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [attrShort, attrDoubleArray, attrStringArray],
         [],
@@ -79,7 +80,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [attrShort, attrLong, attrInt, attrBool],
         [],
@@ -98,7 +100,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [attrShort, attrLong],
         [],
@@ -119,7 +122,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -142,7 +146,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -164,7 +169,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -186,7 +192,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -217,7 +224,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -243,7 +251,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -267,7 +276,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],
@@ -291,7 +301,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [spanLink1, spanLink2],
@@ -314,7 +325,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [spanLink1, spanLink2, spanLink3, spanLink4],
@@ -333,7 +345,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [spanLink3],
@@ -355,7 +368,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [spanLinkStrs],
@@ -386,7 +400,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [spanLinkDup],
@@ -414,7 +429,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [spanLinkNoAttr],

--- a/test/unit/sdk/span_processors/batch_processor_test.dart
+++ b/test/unit/sdk/span_processors/batch_processor_test.dart
@@ -5,7 +5,6 @@
 import 'package:mockito/mockito.dart';
 import 'package:opentelemetry/src/sdk/trace/exporters/span_exporter.dart';
 import 'package:opentelemetry/src/sdk/trace/read_only_span.dart';
-import 'package:opentelemetry/src/api/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_processors/batch_processor.dart';
 import 'package:test/test.dart';
 

--- a/test/unit/sdk/span_processors/simple_processor_test.dart
+++ b/test/unit/sdk/span_processors/simple_processor_test.dart
@@ -4,7 +4,6 @@
 @TestOn('vm')
 import 'package:mockito/mockito.dart';
 import 'package:opentelemetry/src/sdk/trace/exporters/span_exporter.dart';
-import 'package:opentelemetry/src/sdk/trace/read_only_span.dart';
 import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_processors/simple_processor.dart';
 import 'package:test/test.dart';

--- a/test/unit/sdk/span_test.dart
+++ b/test/unit/sdk/span_test.dart
@@ -17,7 +17,8 @@ void main() {
         [],
         sdk.DateTimeTimeProvider(),
         sdk.Resource([api.Attribute.fromString('service-name', 'foo')]),
-        sdk.InstrumentationLibrary('library_name', 'library_version'),
+        sdk.InstrumentationScope(
+            'library_name', 'library_version', 'url://schema', []),
         api.SpanKind.internal,
         [],
         [],


### PR DESCRIPTION
## Which problem is this PR solving?

OpenTelemetry's specification has recently transitioned from using "Instrumentation Library" to "Instrumentation Scope" for certain identifying information.

To ensure that OpenTelemetry Dart remains up-to-date with the specification the InstrumentationLibrary class should be deprecated in favor of an InstrumentationScope class within the SDK package.

## Short description of the change

This PR: 
* Adds usage of the existing `InstrumentationScope` class to relevant locations in SDK code.  
* `InstrumentationLibrary` from SDK and API have been deprecated and will be removed in a future version.
* The version of opentelemetry-protoc submodule referenced by the library has been updated to current (1.0.0). 


## How Has This Been Tested?

* Verified that unit tests pass successfully following this change.
* Loaded this branch into a small testing application and confirmed that it can be used to emit traces.