### PR TITLE
Dart 2.19

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -25,7 +25,7 @@ jobs:
           submodules: true
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.18.7
+          sdk: 2.19.6
       - name: Install protobuf-compiler
         run: sudo apt install -y protobuf-compiler
       - name: Install Dart dependencies
@@ -35,7 +35,7 @@ jobs:
       - name: Format, analyze, and run tests
         run: make test
       - name: Generate Coverage
-        run: dart run test --coverage=./coverage
+        run: dart test --coverage=./coverage
       - name: Activate Coverage Package
         run: dart pub global activate coverage
       - name: Format Coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18.7
+FROM dart:2.19.6
 WORKDIR /build
 
 RUN apt update && apt install -y make protobuf-compiler gnupg wget


### PR DESCRIPTION
Summary
---
This batch updates CI to use Dart 2.19. In some cases updating Just Works™ but here's
some things that have changed or may cause problems while updating.
- The pub and dart2js aliases have been removed. You may need to replace bare pub commands. See the replacements here https://wiki.atl.workiva.net/display/CP/Dart+2.18+FAQ
- There may be some new lints, or lints that actually function better and now find new issues that need fixing or ignoring.
- Some lints may have been raised to warnings that now need fixing or ignoring until fixed.
- Dockerfiles or skynet may try to install things that don't work quite right on newer debian 11 (bullseye)
- If you have build.yaml files that "split" the builders into separate targets, you may have to exclude a new builder
```
  build_resolvers|transitive_digests:
    enabled: false
```

For support go to `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/dart_219`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_219)