### PR TITLE
O11Y-3369: Migrate opentelemetry-dart to GHA

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,10 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-      - '[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?'
+      # Releases
+      - '[0-9]+.[0-9]+.[0-9]+'
+      # Release Candidates
+      - '[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
 
 jobs:
   publish:


### PR DESCRIPTION
## Which problem is this PR solving?

GHA "publish" workflow currently contains incorrect regex, which prevents the workflow from triggering properly.  Workflow regex should conform to the following conventions:  https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

This PR updates the tag regex which triggers a publish to pub.dev.

## How Has This Been Tested?

* Pushed an RC tag to my fork containing these changes.
* Confirmed that "publish" workflow started execution.

https://github.com/michaelyeager-wf/opentelemetry-dart/actions/runs/6701443021/job/18208880198
Failure is expected because the referenced reusable workflow does not have access to my fork.