### PR TITLE
version upgrade, specifically http

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,14 +9,14 @@ dependencies:
   async: '>=2.5.0 <3.0.0'
   collection: ^1.15.0
   fixnum: '>=1.0.0 <2.0.0'
-  http: ^1.1.1
+  http: ^1.1.2
   logging: ^1.0.0
   meta: '>=1.6.0 <2.0.0'
   protobuf: ">=2.0.0 <4.0.0"
   quiver: '>=3.0.0 <4.0.0'
 
 dev_dependencies:
-  build_runner: ^2.3.3
+  build_runner: ^2.4.7
   build_test: ^2.2.1
   build_web_compilers: ^4.0.7
   mockito: ^5.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   async: '>=2.5.0 <3.0.0'
   collection: ^1.15.0
   fixnum: '>=1.0.0 <2.0.0'
-  http: '>=0.13.0 <0.14.0'
+  http: ^1.1.1
   logging: ^1.0.0
   meta: '>=1.6.0 <2.0.0'
   protobuf: ">=2.0.0 <4.0.0"
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.3.3
   build_test: ^2.2.1
-  build_web_compilers: ^3.2.7
+  build_web_compilers: ^4.0.7
   mockito: ^5.4.0
   remove_from_coverage: ^2.0.0
   test: ^1.24.2


### PR DESCRIPTION
## Which problem is this PR solving?

The HTTP dependency is outdated; it prevents other projects from using the latest version. 

Fixes # (issue)

The dependencies are upgraded. 


## How Has This Been Tested?

All unit tests are green
