### PR TITLE
Allow a custom time provider in TracerProviderBase

### DIFF
--- a/lib/src/sdk/trace/tracer_provider.dart
+++ b/lib/src/sdk/trace/tracer_provider.dart
@@ -27,14 +27,19 @@ class TracerProviderBase implements api.TracerProvider {
   @protected
   final sdk.SpanLimits spanLimits;
 
+  @protected
+  final sdk.TimeProvider _timeProvider;
+
   TracerProviderBase(
       {this.processors =
           const [], // Default to a TracerProvider which does not emit traces.
       resource,
+      sdk.TimeProvider? timeProvider,
       this.sampler = const sdk.ParentBasedSampler(sdk.AlwaysOnSampler()),
       this.idGenerator = const sdk.IdGenerator(),
       this.spanLimits = const sdk.SpanLimits()})
-      : resource = resource ?? sdk.Resource([]);
+      : resource = resource ?? sdk.Resource([]),
+        _timeProvider = timeProvider ?? sdk.DateTimeTimeProvider();
 
   List<sdk.SpanProcessor> get spanProcessors => processors;
 
@@ -50,7 +55,7 @@ class TracerProviderBase implements api.TracerProvider {
             processors,
             resource,
             sampler,
-            sdk.DateTimeTimeProvider(),
+            _timeProvider,
             idGenerator,
             sdk.InstrumentationScope(name, version, schemaUrl, attributes),
             spanLimits));

--- a/lib/src/sdk/trace/tracer_provider.dart
+++ b/lib/src/sdk/trace/tracer_provider.dart
@@ -27,7 +27,6 @@ class TracerProviderBase implements api.TracerProvider {
   @protected
   final sdk.SpanLimits spanLimits;
 
-  @protected
   final sdk.TimeProvider _timeProvider;
 
   TracerProviderBase(

--- a/test/unit/sdk/trace_provider_test.dart
+++ b/test/unit/sdk/trace_provider_test.dart
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
 @TestOn('vm')
+import 'package:fixnum/src/int64.dart';
 import 'package:mockito/mockito.dart';
+import 'package:opentelemetry/src/sdk/time_providers/time_provider.dart';
+import 'package:opentelemetry/src/sdk/trace/read_only_span.dart';
 import 'package:opentelemetry/src/sdk/trace/span_processors/span_processor.dart';
 import 'package:opentelemetry/src/sdk/trace/tracer_provider.dart';
 import 'package:test/test.dart';
@@ -36,6 +39,13 @@ void main() {
     expect(provider.spanProcessors, [mockProcessor1, mockProcessor2]);
   });
 
+  test('traceProvider custom timeProvider', () {
+    final mockTimeProvider = FakeTimeProvider(now: Int64(123));
+    final provider = TracerProviderBase(timeProvider: mockTimeProvider);
+    final span = provider.getTracer('foo').startSpan('bar') as ReadOnlySpan;
+    expect(span.startTime, Int64(123));
+  });
+
   test('tracerProvider force flushes all processors', () {
     final mockProcessor1 = MockSpanProcessor();
     final mockProcessor2 = MockSpanProcessor();
@@ -54,4 +64,12 @@ void main() {
     verify(mockProcessor1.shutdown()).called(1);
     verify(mockProcessor2.shutdown()).called(1);
   });
+}
+
+class FakeTimeProvider extends Mock implements TimeProvider {
+  FakeTimeProvider({required Int64 now}) : _now = now;
+  final Int64 _now;
+
+  @override
+  Int64 get now => _now;
 }


### PR DESCRIPTION
This mirrors the capability in WebTracerProvider.

## Which problem is this PR solving?

I have an opentelemetry implementation using the Dart library (thanks!). I've noticed clock skew between my web/flutter client and dart backend. I have clock synchronisation in the client. This PR allows me to provide my own TimeProvider which exposes synchronised time time, nicely aligning traces between app and server.

The [WebTracerProvider constructor](https://github.com/Workiva/opentelemetry-dart/blob/05f63b64fd813710d78a996a0484cb86ca8bcf98/lib/src/sdk/platforms/web/trace/web_tracer_provider.dart#L25) does allow providing a TimeProvider, but cannot be used in non-web platforms.

Fixes # [99](https://github.com/Workiva/opentelemetry-dart/issues/99) which is expanded in [opentelemetry-js 1652](https://github.com/open-telemetry/opentelemetry-js/issues/1652)

## Short description of the change

Simply provide a named parameter to override the default TimeProvider in the TracerProviderBase, as is done in the WebTracerProvider.

## How Has This Been Tested?

I have added a unit test demonstrating a custom time provider.


## Checklist:

- [X] Unit tests have been added
- [ ] Documentation has been updated
  - The README.md references a TimeProvider for WebTracerProvider. Should I update for TracerProviderBase?