### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
  # For anything not explicitly taken by someone else:
-* @Workiva/observability @evanweible-wf @dustinlessard-wf
+* @blakeroberts-wk @evanweible-wf @dustinlessard-wf


### PR DESCRIPTION
## Which problem is this PR solving?
CODEOWNERS does not reflect accurate maintainers for opentelemetry-dart.

## Short description of the change
Update CODEOWNERS to include @blakeroberts-wk as primary maintainer of the opentelemetry-dart project in place of @Workiva/observability 

## How Has This Been Tested?

No tests required

## Checklist:

- [ ] Unit tests have been added
- [ ] Documentation has been updated