### PR TITLE
PPI-165 : fix timestamp rounding issues and expose helpers for high res timestamps

### DIFF
--- a/lib/src/sdk/platforms/web/time_providers/web_time_provider.dart
+++ b/lib/src/sdk/platforms/web/time_providers/web_time_provider.dart
@@ -8,25 +8,31 @@ import 'package:meta/meta.dart';
 
 import '../../../time_providers/time_provider.dart';
 
-int _msToNs(num n) {
-  const nanosecondsPerMillisecond = 1000 * 1000;
-  final whole = n.floor();
-  final frac = ((n - whole) * nanosecondsPerMillisecond).toInt();
-  return whole * nanosecondsPerMillisecond + frac;
+Int64 msToNs(num n, {int? fractionDigits}) {
+  const nsPerMs = 1000 * 1000;
+  final whole = n.truncate();
+  if (fractionDigits == null) {
+    final frac = ((n - whole) * nsPerMs).round();
+    return Int64(whole * nsPerMs + frac);
+  }
+  final frac =
+      double.parse((n - whole).toStringAsFixed(fractionDigits)) * nsPerMs;
+  return Int64(whole) * nsPerMs + Int64(frac.round());
 }
 
 /// Time when navigation started or the service worker was started in
 /// nanoseconds.
 @experimental
-final Int64 timeOrigin = Int64(_msToNs(window.performance.timeOrigin ??
-    window.performance.timing.navigationStart));
+final Int64 timeOrigin = msToNs(
+    window.performance.timeOrigin ?? window.performance.timing.navigationStart,
+    fractionDigits: 1);
 
 /// The time elapsed since the time origin, in nanoseconds.
 @experimental
 Int64 now() => _now();
 
 Int64 _now() {
-  return Int64(_msToNs(window.performance.now()));
+  return msToNs(window.performance.now());
 }
 
 /// BrowserTimeProvider retrieves high-resolution timestamps utilizing the

--- a/lib/src/sdk/platforms/web/time_providers/web_time_provider.dart
+++ b/lib/src/sdk/platforms/web/time_providers/web_time_provider.dart
@@ -27,12 +27,11 @@ final Int64 timeOrigin = msToNs(
     window.performance.timeOrigin ?? window.performance.timing.navigationStart,
     fractionDigits: 1);
 
-/// The time elapsed since the time origin, in nanoseconds.
+/// Converts a high-resolution timestamp from the browser performance API to an
+/// Int64 representing nanoseconds since Unix Epoch.
 @experimental
-Int64 now() => _now();
-
-Int64 _now() {
-  return msToNs(window.performance.now());
+Int64 fromDOMHighResTimeStamp(num ts) {
+  return timeOrigin + msToNs(ts);
 }
 
 /// BrowserTimeProvider retrieves high-resolution timestamps utilizing the
@@ -51,5 +50,5 @@ class WebTimeProvider implements TimeProvider {
   /// for sleep.  See https://github.com/open-telemetry/opentelemetry-js/issues/852
   /// for more information.
   @override
-  Int64 get now => timeOrigin + _now();
+  Int64 get now => fromDOMHighResTimeStamp(window.performance.now());
 }

--- a/lib/src/sdk/platforms/web/time_providers/web_time_provider.dart
+++ b/lib/src/sdk/platforms/web/time_providers/web_time_provider.dart
@@ -2,11 +2,32 @@
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
 import 'dart:html';
-import 'dart:js';
 
 import 'package:fixnum/fixnum.dart';
+import 'package:meta/meta.dart';
 
-import '../../../../../sdk.dart' as sdk;
+import '../../../time_providers/time_provider.dart';
+
+int _msToNs(num n) {
+  const nanosecondsPerMillisecond = 1000 * 1000;
+  final whole = n.floor();
+  final frac = ((n - whole) * nanosecondsPerMillisecond).toInt();
+  return whole * nanosecondsPerMillisecond + frac;
+}
+
+/// Time when navigation started or the service worker was started in
+/// nanoseconds.
+@experimental
+final Int64 timeOrigin = Int64(_msToNs(window.performance.timeOrigin ??
+    window.performance.timing.navigationStart));
+
+/// The time elapsed since the time origin, in nanoseconds.
+@experimental
+Int64 now() => _now();
+
+Int64 _now() {
+  return Int64(_msToNs(window.performance.now()));
+}
 
 /// BrowserTimeProvider retrieves high-resolution timestamps utilizing the
 /// `window.performance` API.
@@ -17,23 +38,12 @@ import '../../../../../sdk.dart' as sdk;
 /// Note that this time may be inaccurate if the executing system is suspended
 /// for sleep.  See https://github.com/open-telemetry/opentelemetry-js/issues/852
 /// for more information.
-class WebTimeProvider implements sdk.TimeProvider {
-  static final Int64 _timeOrigin = _fromDouble(
-      JsObject.fromBrowserObject(window)['performance']['timeOrigin'] ??
-          // fallback for browsers that don't support timeOrigin, like Dartium
-          window.performance.timing.navigationStart.toDouble());
-
-  /// Derive a time, in nanoseconds, from a floating-point time, in milliseconds.
-  static Int64 _fromDouble(double time) =>
-      Int64((time * sdk.TimeProvider.nanosecondsPerMillisecond).round());
-
+class WebTimeProvider implements TimeProvider {
   /// The current time, in nanoseconds since Unix Epoch.
   ///
   /// Note that this time may be inaccurate if the executing system is suspended
   /// for sleep.  See https://github.com/open-telemetry/opentelemetry-js/issues/852
   /// for more information.
   @override
-  Int64 get now =>
-      // .now() returns an int in Dartium, requiring .toDouble()
-      _timeOrigin + _fromDouble(window.performance.now().toDouble());
+  Int64 get now => timeOrigin + _now();
 }

--- a/lib/src/sdk/time_providers/datetime_time_provider.dart
+++ b/lib/src/sdk/time_providers/datetime_time_provider.dart
@@ -7,7 +7,5 @@ import 'time_provider.dart';
 /// DateTimeTimeProvider retrieves timestamps using DateTime.
 class DateTimeTimeProvider implements TimeProvider {
   @override
-  Int64 get now =>
-      Int64(DateTime.now().microsecondsSinceEpoch) *
-      TimeProvider.nanosecondsPerMicrosecond;
+  Int64 get now => Int64(DateTime.now().microsecondsSinceEpoch) * 1000;
 }

--- a/lib/src/sdk/time_providers/time_provider.dart
+++ b/lib/src/sdk/time_providers/time_provider.dart
@@ -6,10 +6,12 @@ import 'package:fixnum/fixnum.dart';
 abstract class TimeProvider {
   // The smallest increment that DateTime can report is in microseconds, while
   // OpenTelemetry expects time in nanoseconds.
+  @Deprecated('This constant will be removed in 0.19.0 without replacement.')
   static const int nanosecondsPerMicrosecond = 1000;
 
   // window.performance API reports time in fractional milliseconds, while
   // OpenTelemetry expects time in nanoseconds.
+  @Deprecated('This constant will be removed in 0.19.0 without replacement.')
   static const int nanosecondsPerMillisecond = 1000000;
 
   /// The current time, in nanoseconds since Unix Epoch.

--- a/lib/web_sdk.dart
+++ b/lib/web_sdk.dart
@@ -2,6 +2,6 @@
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
 export 'src/sdk/platforms/web/time_providers/web_time_provider.dart'
-    show WebTimeProvider;
+    show now, timeOrigin, WebTimeProvider;
 export 'src/sdk/platforms/web/trace/web_tracer_provider.dart'
     show WebTracerProvider;

--- a/lib/web_sdk.dart
+++ b/lib/web_sdk.dart
@@ -2,6 +2,6 @@
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
 export 'src/sdk/platforms/web/time_providers/web_time_provider.dart'
-    show now, timeOrigin, WebTimeProvider;
+    show fromDOMHighResTimeStamp, timeOrigin, WebTimeProvider;
 export 'src/sdk/platforms/web/trace/web_tracer_provider.dart'
     show WebTracerProvider;

--- a/test/unit/sdk/platforms/web/web_time_provider_test.dart
+++ b/test/unit/sdk/platforms/web/web_time_provider_test.dart
@@ -2,31 +2,34 @@
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
 @TestOn('chrome')
-import 'package:opentelemetry/api.dart' as api;
-import 'package:opentelemetry/sdk.dart' as sdk;
+
+import 'package:fixnum/fixnum.dart';
 import 'package:opentelemetry/src/sdk/platforms/web/time_providers/web_time_provider.dart';
-import 'package:opentelemetry/src/sdk/trace/span.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('records start and end times with browser performance API', () async {
-    final span = Span(
-        'testStartAndEndTimes',
-        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, api.TraceState.empty()),
-        api.SpanId([4, 5, 6]),
-        [],
-        WebTimeProvider(),
-        sdk.Resource([]),
-        sdk.InstrumentationScope(
-            'library_name', 'library_version', 'url://schema', []),
-        api.SpanKind.internal,
-        [],
-        sdk.SpanLimits(),
-        WebTimeProvider().now)
-      ..end();
-
-    expect(span.endTime, isNotNull);
-    expect(span.startTime, lessThanOrEqualTo(span.endTime!));
+  group('msToNs', () {
+    test('msToNs rounds large fractions', () {
+      final cases = [
+        [809.2223347138977, Int64(809222335)],
+        [821.5999999046326, Int64(821600000)],
+        [1427.1999998092651, Int64(1427200000)],
+      ];
+      for (final c in cases) {
+        final expected = c[1];
+        expect(msToNs(c[0] as double), expected);
+      }
+    });
+    test('msToNs rounds large wholes', () {
+      final cases = [
+        [1722291888610.5, Int64(17222918886105000) * 100],
+        [1722292170313.4, Int64(17222921703134000) * 100],
+        [1722292193622.1, Int64(17222921936221000) * 100],
+      ];
+      for (final c in cases) {
+        final expected = c[1];
+        expect(msToNs(c[0] as double, fractionDigits: 1), expected);
+      }
+    });
   });
 }


### PR DESCRIPTION
## Which problem is this PR solving?

`WebTimeProvider` suffers from rounding issues when using `window.performance.timeOrigin`:

```text
raw (ms) 1722292170313.4
cur (ns) 1722292170313399800
```

The output above comes from the following script:

```dart
// import 'dart:html';

const int _nanosecondsPerMillisecond = 1000 * 1000;

void main() {
  final raw = 1722292170313.4;
  print('raw (ms) $raw');

  final cur = (raw * _nanosecondsPerMillisecond).round();
  print('cur (ns) ${cur}');

//   final raw = window.performance.timeOrigin ??
//       window.performance.timing.navigationStart;
//   final cur = (raw * _nanosecondsPerMillisecond).round();
//   print('raw now (ms) ${raw}');
//   print('cur now (ns) ${cur}');
}
```

## Short description of the change

Update conversion from doubles representing milliseconds to int64s representing nanoseconds.

Additionally, experimental helper methods have been exposed from the web_sdk package to assist with using timestamps from the performance API as timestamps in OpenTelemetry (span start time, end time, span event timestamps).

## How Has This Been Tested?

Used dart pad, unit tests, and an example app which created spans from performance entry timestamps.

## Checklist:

- [x] Unit tests have been added
- [ ] Documentation has been updated