### PR TITLE
O11Y-4831: Use test URL in test

### DIFF
--- a/test/unit/sdk/exporters/collector_exporter_test.dart
+++ b/test/unit/sdk/exporters/collector_exporter_test.dart
@@ -25,7 +25,7 @@ import '../../mocks.dart';
 void main() {
   late MockHttpClient mockClient;
   final uri =
-      Uri.parse('https://h.wdesk.org/s/opentelemetry-collector/v1/traces');
+      Uri.parse('https://example.test/s/opentelemetry-collector/v1/traces');
 
   setUp(() {
     mockClient = MockHttpClient();


### PR DESCRIPTION
## Which problem is this PR solving?

The wo11y-dart tests refer to the public OTel endpoint. Tests should not use real URLs, but should instead use the `.test` domain, preferably with some arbitrary subdomain.

https://workiva.sourcegraphcloud.com/github.com/Workiva/opentelemetry-dart@9cc09112c1b4ef1f574fe7850f0ef7cdc4f87e96/-/blob/test/unit/sdk/exporters/collector_exporter_test.dart

## How Has This Been Tested?

Unit tests

## Checklist:

- [x] Unit tests have been added
- [ ] Documentation has been updated