### PR TITLE
Make registerGlobalContextManager public API

### DIFF
--- a/example/noop_context_manager.dart
+++ b/example/noop_context_manager.dart
@@ -1,8 +1,7 @@
 import 'package:opentelemetry/api.dart';
 import 'package:opentelemetry/sdk.dart'
     show ConsoleExporter, SimpleSpanProcessor, TracerProviderBase;
-import 'package:opentelemetry/src/experimental_api.dart'
-    show NoopContextManager, registerGlobalContextManager;
+import 'package:opentelemetry/src/experimental_api.dart' show NoopContextManager;
 
 void main(List<String> args) async {
   final tp =

--- a/example/w3c_context_propagation.dart
+++ b/example/w3c_context_propagation.dart
@@ -1,8 +1,7 @@
 import 'package:opentelemetry/api.dart';
 import 'package:opentelemetry/sdk.dart'
     show ConsoleExporter, SimpleSpanProcessor, TracerProviderBase;
-import 'package:opentelemetry/src/experimental_api.dart'
-    show NoopContextManager, registerGlobalContextManager;
+import 'package:opentelemetry/src/experimental_api.dart' show NoopContextManager;
 
 class MapSetter implements TextMapSetter<Map> {
   @override

--- a/example/zone_context_manager.dart
+++ b/example/zone_context_manager.dart
@@ -4,7 +4,7 @@ import 'package:opentelemetry/api.dart';
 import 'package:opentelemetry/sdk.dart'
     show ConsoleExporter, SimpleSpanProcessor, TracerProviderBase;
 import 'package:opentelemetry/src/experimental_api.dart'
-    show registerGlobalContextManager, ZoneContext, ZoneContextManager;
+    show ZoneContext, ZoneContextManager;
 
 void main(List<String> args) async {
   final tp =

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -12,7 +12,10 @@ export 'src/api/context/context.dart'
         contextWithSpanContext,
         spanContextFromContext,
         spanFromContext;
-export 'src/api/context/context_manager.dart' show globalContextManager;
+export 'src/api/context/context_manager.dart' 
+    show
+        globalContextManager,
+        registerGlobalContextManager;
 export 'src/api/exporters/span_exporter.dart' show SpanExporter;
 export 'src/api/instrumentation_library.dart' show InstrumentationLibrary;
 export 'src/api/open_telemetry.dart'

--- a/lib/src/experimental_api.dart
+++ b/lib/src/experimental_api.dart
@@ -6,8 +6,7 @@ library experimental_api;
 
 import 'package:meta/meta.dart';
 
-export 'api/context/context_manager.dart'
-    show ContextManager, registerGlobalContextManager;
+export 'api/context/context_manager.dart' show ContextManager;
 export 'api/context/noop_context_manager.dart' show NoopContextManager;
 export 'api/context/zone_context.dart' show ZoneContext;
 export 'api/context/zone_context_manager.dart' show ZoneContextManager;


### PR DESCRIPTION
## Which problem is this PR solving?

`dart analyze` throws a warning when importing experimental libraries due to this [linting rule](https://dart.dev/tools/linter-rules/implementation_imports). This PR moves an experimental API into the public API so that it can be consumed by a production app.

## Checklist:

- [ ] Unit tests have been added
- [ ] Documentation has been updated