### PR TITLE
Update trace exporter to include trace state and drop counts

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,78 +1,48 @@
+// Copyright 2021-2022 Workiva.
+// Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
+
 import 'package:opentelemetry/api.dart';
 import 'package:opentelemetry/sdk.dart';
 
-/// Applications use a tracer to create a trace with spans. There are several
-/// steps needed to get a tracer.
+/// Applications use a tracer to create sets of spans that constitute a trace.
+/// There are several components needed to get a tracer:
 
-/// Send span details to the console. Use [CollectorExporter] to export traces.
+/// An exporter is needed to send ended spans to a backend such as the dev
+/// console.
 final exporter = ConsoleExporter();
 
-/// Immediately export spans. Use [BatchSpanProcessor] to batch export.
+/// A processor is needed to handle starting and ending spans. The
+/// [SimpleSpanProcessor] doesn't do any processing and immediately forwards
+/// ended spans to the exporter. This is in contrast to the [BatchSpanProcessor]
+/// which will batch spans together before forwarding them to the exporter.
 final processor = SimpleSpanProcessor(exporter);
 
-/// A native Dart tracer. Use WebTracerProvider for web applications.
+/// Finally, a [TracerProvider] is configured with any number of processors.
+/// [TracerProviderBase] is suitable for applications run in the VM whereas
+/// a WebTracerProvider is suited for applications transpiled to JavaScript to
+/// run in a browser.
 final provider = TracerProviderBase(processors: [processor]);
+
+// The [TracerProvider] is the mechanism used to get a [Tracer].
 final tracer = provider.getTracer('instrumentation-name');
 
-/// Demonstrate creating/propagating a trace with a root and child spans.
-///
-/// The output to the console shows the trace propagation and the span details.
-/// Example output:
-/// Include headers on your outgoing request (http, grpc, etc):
-///   {traceparent: 00-a6493775da5822fb964d2117f64d588f-df484a3f05b1946f-01,
-///    tracestate: }
-/// Using finally to ensure the child span is exported.
-///   {traceId: a6493775da5822fb964d2117f64d588f, parentId: 365589c23f2e5d7c,
-///    name: child-span, id: df484a3f05b1946f, timestamp: 1710865958436020000,
-///    duration: 7032000, flags: 01, state: , status: StatusCode.unset}
-/// The root span is ended and exported to the console.
-///   {traceId: a6493775da5822fb964d2117f64d588f, parentId: , name: root-span,
-///    id: 365589c23f2e5d7c, timestamp: 1710865958424782000, duration: 19892000,
-///    flags: 01, state: , status: StatusCode.unset}
-void main() {
-  // The current span is available via the global Context.
-  final context = Context.current;
+/// Demonstrates creating a trace with a parent and child span.
+void main() async {
+  // The current active span is available via the global context manager.
+  var context = globalContextManager.active;
+
   // A trace starts with a root span which has no parent.
-  final rootSpan = tracer.startSpan('root-span');
-  try {
-    // A callback is required to set the rootSpan as the current context.
-    context.withSpan(rootSpan).execute(() {
-      final childSpan = tracer.startSpan('child-span',
-          kind: SpanKind.client,
-          attributes: [Attribute.fromString('key', 'useful information...')]);
-      try {
-        Context.current.withSpan(childSpan).execute(remoteProceedureCall);
-        childSpan.addEvent('Some work was done!');
-      } catch (e) {
-        childSpan
-          ..recordException(e)
-          ..setStatus(StatusCode.error, 'An error occurred');
-      } finally {
-        print('Using finally to ensure the child span is exported.');
-        childSpan.end();
-      }
-    });
-  } finally {
-    print('The root span is ended and exported to the console.');
-    rootSpan.end();
-  }
-  rootSpan.end();
-}
+  final parentSpan = tracer.startSpan('parent-span');
 
-/// Simulate calling a remote process. The trace context needs to be propogated.
-/// See https://www.w3.org/TR/trace-context/ 'traceparent' and 'tracestate'.
-Future<void> remoteProceedureCall() async {
-  final headers = <String, String>{};
-  W3CTraceContextPropagator()
-      .inject(Context.current, headers, _TextMapSetter());
-  print('Include headers on your outgoing request (http, grpc, etc): $headers');
-  // Use W3CTraceContextPropagator().extract to get the trace context on the
-  // receiving side.
-}
+  // A new context can be created in order to propagate context manually.
+  context = contextWithSpan(context, parentSpan);
 
-class _TextMapSetter implements TextMapSetter<Map<String, String>> {
-  @override
-  void set(Map<String, String> carrier, String key, String value) {
-    carrier[key] = value;
-  }
+  // The traceContext and traceContextSync functions will automatically
+  // propagate context, capture errors, and end the span.
+  await traceContext(
+      'child-span', (_context) => Future.delayed(Duration(milliseconds: 100)),
+      context: context);
+
+  // Spans must be ended or they will not be exported.
+  parentSpan.end();
 }

--- a/example/noop_context_manager.dart
+++ b/example/noop_context_manager.dart
@@ -1,3 +1,6 @@
+// Copyright 2021-2022 Workiva.
+// Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
+
 import 'package:opentelemetry/api.dart';
 import 'package:opentelemetry/sdk.dart'
     show ConsoleExporter, SimpleSpanProcessor, TracerProviderBase;

--- a/example/w3c_context_propagation.dart
+++ b/example/w3c_context_propagation.dart
@@ -1,3 +1,6 @@
+// Copyright 2021-2022 Workiva.
+// Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
+
 import 'package:opentelemetry/api.dart';
 import 'package:opentelemetry/sdk.dart'
     show ConsoleExporter, SimpleSpanProcessor, TracerProviderBase;

--- a/example/zone_context_manager.dart
+++ b/example/zone_context_manager.dart
@@ -1,3 +1,6 @@
+// Copyright 2021-2022 Workiva.
+// Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
+
 import 'dart:async';
 
 import 'package:opentelemetry/api.dart';

--- a/lib/src/api/trace/span_link.dart
+++ b/lib/src/api/trace/span_link.dart
@@ -6,6 +6,8 @@ import '../../../api.dart' as api;
 class SpanLink {
   final api.SpanContext context;
   final List<api.Attribute> attributes;
+  final int droppedAttributes;
 
-  SpanLink(this.context, {this.attributes = const []});
+  SpanLink(this.context,
+      {this.attributes = const [], this.droppedAttributes = 0});
 }

--- a/lib/src/sdk/common/limits.dart
+++ b/lib/src/sdk/common/limits.dart
@@ -23,31 +23,34 @@ List<api.SpanLink> applyLinkLimits(
     // make sure override duplicated attributes in the list
     final attributeMap = <String, int>{};
 
+    var droppedAttributes = 0;
     for (final attr in link.attributes) {
       // if attributes num is already greater than maxNumAttributesPerLink
       // and this key doesn't exist in the list, drop it.
       if (attributeMap.length >= limits.maxNumAttributesPerLink &&
           !attributeMap.containsKey(attr.key)) {
+        droppedAttributes++;
         continue;
       }
 
       // apply maxNumAttributeLength limit.
-      final trimedAttr = applyAttributeLimits(attr, limits);
+      final trimmedAttr = applyAttributeLimits(attr, limits);
 
       // if this key has been added before, find its index,
       // and replace it with new value.
       final idx = attributeMap[attr.key];
       if (idx != null) {
-        linkAttributes[idx] = trimedAttr;
+        linkAttributes[idx] = trimmedAttr;
       } else {
         // record this new key's index with linkAttributes length,
         // and add this new attr in linkAttributes.
         attributeMap[attr.key] = linkAttributes.length;
-        linkAttributes.add(trimedAttr);
+        linkAttributes.add(trimmedAttr);
       }
     }
 
-    spanLink.add(api.SpanLink(link.context, attributes: linkAttributes));
+    spanLink.add(api.SpanLink(link.context,
+        attributes: linkAttributes, droppedAttributes: droppedAttributes));
   }
   return spanLink;
 }

--- a/lib/src/sdk/trace/exporters/collector_exporter.dart
+++ b/lib/src/sdk/trace/exporters/collector_exporter.dart
@@ -109,7 +109,9 @@ class CollectorExporter implements sdk.SpanExporter {
           traceId: link.context.traceId.get(),
           spanId: link.context.spanId.get(),
           traceState: link.context.traceState.toString(),
-          attributes: attrs));
+          attributes: attrs,
+          droppedAttributesCount: link.droppedAttributes,
+          flags: link.context.traceFlags));
     }
     return pbLinks;
   }
@@ -162,22 +164,28 @@ class CollectorExporter implements sdk.SpanExporter {
     }
 
     return pb_trace.Span(
-        traceId: span.spanContext.traceId.get(),
-        spanId: span.spanContext.spanId.get(),
-        parentSpanId: span.parentSpanId.get(),
-        name: span.name,
-        startTimeUnixNano: span.startTime,
-        endTimeUnixNano: span.endTime,
-        attributes: span.attributes.keys.map((key) => pb_common.KeyValue(
-            key: key,
-            value: _attributeValueToProtobuf(span.attributes.get(key)!))),
-        events: _spanEventsToProtobuf(span.events),
-        droppedEventsCount:
-            span.events.isNotEmpty ? span.droppedEventsCount : null,
-        status:
-            pb_trace.Status(code: statusCode, message: span.status.description),
-        kind: spanKind,
-        links: _spanLinksToProtobuf(span.links));
+      traceId: span.spanContext.traceId.get(),
+      spanId: span.spanContext.spanId.get(),
+      traceState: span.spanContext.traceState.toString(),
+      parentSpanId: span.parentSpanId.get(),
+      name: span.name,
+      kind: spanKind,
+      startTimeUnixNano: span.startTime,
+      endTimeUnixNano: span.endTime,
+      attributes: span.attributes.keys.map((key) => pb_common.KeyValue(
+          key: key,
+          value: _attributeValueToProtobuf(span.attributes.get(key)!))),
+      droppedAttributesCount:
+          span.attributes.length > 0 ? span.droppedAttributes : null,
+      events: _spanEventsToProtobuf(span.events),
+      droppedEventsCount:
+          span.events.isNotEmpty ? span.droppedEventsCount : null,
+      links: _spanLinksToProtobuf(span.links),
+      droppedLinksCount: span.links.isNotEmpty ? span.droppedLinksCount : null,
+      status:
+          pb_trace.Status(code: statusCode, message: span.status.description),
+      flags: span.spanContext.traceFlags,
+    );
   }
 
   pb_common.AnyValue _attributeValueToProtobuf(Object value) {

--- a/lib/src/sdk/trace/read_only_span.dart
+++ b/lib/src/sdk/trace/read_only_span.dart
@@ -46,7 +46,11 @@ abstract class ReadOnlySpan {
 
   List<api.SpanLink> get links;
 
+  int get droppedLinksCount;
+
   Attributes get attributes;
+
+  int get droppedAttributes;
 
   sdk.Resource get resource;
 }

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -8,7 +8,7 @@ import 'package:opentelemetry/api.dart';
 import '../../../api.dart' as api;
 import '../../../sdk.dart' as sdk;
 import '../common/attributes.dart';
-import '../common/limits.dart' show applyAttributeLimits;
+import '../common/limits.dart' show applyAttributeLimits, applyLinkLimits;
 
 /// A representation of a single operation within a trace.
 @protected
@@ -26,6 +26,7 @@ class Span implements sdk.ReadWriteSpan {
   final Int64 _startTime;
   final Attributes _attributes = Attributes.empty();
   final List<api.SpanEvent> _events = [];
+  late final int _droppedSpanLinks;
 
   String _name;
   int _droppedSpanAttributes = 0;
@@ -54,9 +55,12 @@ class Span implements sdk.ReadWriteSpan {
       this._resource,
       this._instrumentationScope,
       this._kind,
-      this._links,
+      links,
       this._limits,
-      this._startTime);
+      this._startTime)
+      : _links = applyLinkLimits(links, _limits) {
+    _droppedSpanLinks = links.length - _links.length;
+  }
 
   @override
   api.SpanContext get spanContext => _spanContext;
@@ -199,8 +203,12 @@ class Span implements sdk.ReadWriteSpan {
   List<api.SpanLink> get links => List.unmodifiable(_links);
 
   @override
+  int get droppedLinksCount => _droppedSpanLinks;
+
+  @override
   Attributes get attributes => _attributes;
 
+  @override
   int get droppedAttributes => _droppedSpanAttributes;
 
   @override

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -55,7 +55,7 @@ class Span implements sdk.ReadWriteSpan {
       this._resource,
       this._instrumentationScope,
       this._kind,
-      links,
+      List<SpanLink> links,
       this._limits,
       this._startTime)
       : _links = applyLinkLimits(links, _limits) {

--- a/test/unit/sdk/exporters/collector_exporter_test.dart
+++ b/test/unit/sdk/exporters/collector_exporter_test.dart
@@ -96,8 +96,10 @@ void main() {
                   pb.Span(
                       traceId: [1, 2, 3],
                       spanId: [7, 8, 9],
+                      traceState: '',
                       parentSpanId: [4, 5, 6],
                       name: 'foo',
+                      kind: pb.Span_SpanKind.SPAN_KIND_CLIENT,
                       startTimeUnixNano: span1.startTime,
                       endTimeUnixNano: span1.endTime,
                       attributes: [
@@ -105,15 +107,18 @@ void main() {
                             key: 'foo',
                             value: pb_common.AnyValue(stringValue: 'bar'))
                       ],
+                      droppedAttributesCount: 0,
                       status: pb.Status(
                           code: pb.Status_StatusCode.STATUS_CODE_UNSET,
                           message: ''),
-                      kind: pb.Span_SpanKind.SPAN_KIND_CLIENT),
+                      flags: 0),
                   pb.Span(
                       traceId: [1, 2, 3],
                       spanId: [10, 11, 12],
+                      traceState: '',
                       parentSpanId: [4, 5, 6],
                       name: 'baz',
+                      kind: pb.Span_SpanKind.SPAN_KIND_INTERNAL,
                       startTimeUnixNano: span2.startTime,
                       endTimeUnixNano: span2.endTime,
                       attributes: [
@@ -121,6 +126,7 @@ void main() {
                             key: 'bool',
                             value: pb_common.AnyValue(boolValue: true))
                       ],
+                      droppedAttributesCount: 0,
                       events: [
                         pb.Span_Event(
                           timeUnixNano: span2.events.first.timestamp,
@@ -137,7 +143,6 @@ void main() {
                       status: pb.Status(
                           code: pb.Status_StatusCode.STATUS_CODE_UNSET,
                           message: ''),
-                      kind: pb.Span_SpanKind.SPAN_KIND_INTERNAL,
                       links: [
                         pb.Span_Link(
                             traceId: [1, 2, 3],
@@ -148,8 +153,12 @@ void main() {
                                   key: 'longKey',
                                   value:
                                       pb_common.AnyValue(stringValue: 'I am '))
-                            ])
-                      ])
+                            ],
+                            droppedAttributesCount: 0,
+                            flags: 0)
+                      ],
+                      droppedLinksCount: 0,
+                      flags: 0)
                 ],
                 scope: pb_common.InstrumentationScope(
                     name: 'library_name', version: 'library_version'))

--- a/test/unit/sdk/trace/tracer_test.dart
+++ b/test/unit/sdk/trace/tracer_test.dart
@@ -1,3 +1,6 @@
+// Copyright 2021-2022 Workiva.
+// Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
+
 @TestOn('vm')
 
 import 'package:opentelemetry/api.dart' as api;


### PR DESCRIPTION
## Which problem is this PR solving?

The exporter does not include:
- trace state on the span
- dropped span attributes count
- dropped span links count
- dropped link attributes count

Fixes N/A

## Short description of the change

The exporter will export:
- trace state on the span
- dropped span attributes count
- dropped span links count
- dropped link attributes count

## How Has This Been Tested?

Pulled changes into a deployed app and spans were successfully exported and retrieved from a trace backend.

## Checklist:

- [x] Unit tests have been added
- [x] Documentation has been updated