### PR TITLE
FEDX-1749: allow attributes to be set

### DIFF
--- a/lib/src/api/open_telemetry.dart
+++ b/lib/src/api/open_telemetry.dart
@@ -69,7 +69,7 @@ Future<T> traceContext<T>(String name, Future<T> Function(api.Context) fn,
     api.Tracer? tracer,
     bool newRoot = false,
     api.SpanKind spanKind = api.SpanKind.internal,
-    List<api.SpanLink> spanLinks = const []}) async {
+    List<api.SpanLink> spanLinks = const [], List<api.Attribute> attributes = const[]}) async {
   context ??= api.globalContextManager.active;
   tracer ??= _tracerProvider.getTracer('opentelemetry-dart');
 
@@ -81,6 +81,7 @@ Future<T> traceContext<T>(String name, Future<T> Function(api.Context) fn,
   final span = tracer.startSpan(name,
       context: context, kind: spanKind, links: spanLinks);
   context = api.contextWithSpan(context, span);
+  span.setAttributes(attributes);
   try {
     // TODO: remove this check once `run` exists on context interface
     if (context is ZoneContext) {

--- a/lib/src/api/open_telemetry.dart
+++ b/lib/src/api/open_telemetry.dart
@@ -81,7 +81,7 @@ Future<T> traceContext<T>(String name, Future<T> Function(api.Context) fn,
   final span = tracer.startSpan(name,
       context: context, kind: spanKind, links: spanLinks);
   context = api.contextWithSpan(context, span);
-  span.setAttributes(attributes);
+  
   try {
     // TODO: remove this check once `run` exists on context interface
     if (context is ZoneContext) {
@@ -94,6 +94,7 @@ Future<T> traceContext<T>(String name, Future<T> Function(api.Context) fn,
       ..recordException(e, stackTrace: s);
     rethrow;
   } finally {
+    span.setAttributes(attributes);
     span.end();
   }
 }

--- a/test/integration/open_telemetry_test.dart
+++ b/test/integration/open_telemetry_test.dart
@@ -114,13 +114,15 @@ void main() {
         sdk.InstrumentationScope('name', 'version', 'url://schema', []),
         sdk.SpanLimits());
     final spans = <Span>[];
+    const expectedKey = 'myKey';
+    const expectedValue = 'myValue';
 
     for (var i = 0; i < 5; i++) {
       await api.traceContext('asyncTrace', (context) async {
         spans.add(api.spanFromContext(context) as Span);
-      }, tracer: tracer);
+      }, attributes: [api.Attribute.fromString(expectedKey,expectedValue)], tracer: tracer);
     }
-
+      expect(spans[0].attributes.get(expectedKey), expectedValue);
     for (var i = 1; i < spans.length; i++) {
       expect(spans[1].endTime, isNotNull);
       expect(spans[i].startTime, greaterThan(spans[i - 1].startTime));


### PR DESCRIPTION
## Which problem is this PR solving?

I'm looking to use the [traceContext](https://github.com/Workiva/opentelemetry-dart/blob/master/lib/src/api/open_telemetry.dart#L67) function for tracing a function, but would like to append an attribute to the span that is being generated for this function

Fixes # (issue)

## Short description of the change
- Allow a list of attributes to be included

## How Has This Been Tested?
- integration test

Please describe the tests that you ran to verify your change. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Checklist:

- [x] Integation tests have been updated
- [ ] Documentation has been updated