### PR TITLE
WriteToBuffer before call client.post

### DIFF
--- a/lib/src/sdk/trace/exporters/collector_exporter.dart
+++ b/lib/src/sdk/trace/exporters/collector_exporter.dart
@@ -47,11 +47,12 @@ class CollectorExporter implements sdk.SpanExporter {
   ) async {
     try {
       final body = pb_trace_service.ExportTraceServiceRequest(
-          resourceSpans: _spansToProtobuf(spans));
+              resourceSpans: _spansToProtobuf(spans))
+          .writeToBuffer();
       final headers = {'Content-Type': 'application/x-protobuf'}
         ..addAll(this.headers);
 
-      await client.post(uri, body: body.writeToBuffer(), headers: headers);
+      await client.post(uri, body: body, headers: headers);
     } catch (e) {
       _log.warning('Failed to export ${spans.length} spans.', e);
     }


### PR DESCRIPTION
## Which problem is this PR solving?

In order to use custom http client, give the user to override client.post, the body needs to be ready for use. 

Fixes # (issue)

## Short description of the change
Call WriteToBuffer into the body parameter. 


## How Has This Been Tested?

Current test is enough to cover this change. 


## Checklist:

- [ ] Unit tests have been added
- [ ] Documentation has been updated