### PR TITLE
O11Y-5250: Add retry

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -12,10 +12,8 @@ export 'src/api/context/context.dart'
         contextWithSpanContext,
         spanContextFromContext,
         spanFromContext;
-export 'src/api/context/context_manager.dart' 
-    show
-        globalContextManager,
-        registerGlobalContextManager;
+export 'src/api/context/context_manager.dart'
+    show globalContextManager, registerGlobalContextManager;
 export 'src/api/exporters/span_exporter.dart' show SpanExporter;
 export 'src/api/instrumentation_library.dart' show InstrumentationLibrary;
 export 'src/api/open_telemetry.dart'

--- a/lib/src/sdk/trace/exporters/collector_exporter.dart
+++ b/lib/src/sdk/trace/exporters/collector_exporter.dart
@@ -29,7 +29,8 @@ class CollectorExporter implements sdk.SpanExporter {
       : client = httpClient ?? http.Client();
 
   @override
-  void export(List<sdk.ReadOnlySpan> spans) async {
+  Future<void> export(List<sdk.ReadOnlySpan> spans) async {
+    print('export func => _isShutdown: $_isShutdown');
     if (_isShutdown) {
       return;
     }
@@ -46,7 +47,6 @@ class CollectorExporter implements sdk.SpanExporter {
     List<sdk.ReadOnlySpan> spans,
   ) async {
     const maxRetries = 3;
-    const retryDelay = Duration(seconds: 1);
     var retries = 0;
 
     final body = pb_trace_service.ExportTraceServiceRequest(
@@ -63,10 +63,10 @@ class CollectorExporter implements sdk.SpanExporter {
         }
         _log.warning('Failed to export ${spans.length} spans. '
             'HTTP status code: ${response.statusCode}');
-      } catch (e, statckTrace) {
-        _log.warning('Failed to export ${spans.length} spans.', e, statckTrace);
+      } catch (e) {
+        _log.warning('Failed to export ${spans.length} spans. $e');
       }
-      await Future.delayed(retryDelay);
+      //await Future.delayed(Duration(seconds: retries));
     }
     _log.severe(
         'Failed to export ${spans.length} spans after $maxRetries retries');
@@ -260,5 +260,6 @@ class CollectorExporter implements sdk.SpanExporter {
   void shutdown() {
     _isShutdown = true;
     client.close();
+    print('shutdown() func => _isShutdown: $_isShutdown');
   }
 }

--- a/test/unit/sdk/exporters/collector_exporter_test.dart
+++ b/test/unit/sdk/exporters/collector_exporter_test.dart
@@ -24,306 +24,331 @@ import 'package:test/test.dart';
 import '../../mocks.dart';
 
 void main() {
-  late MockHttpClient mockClient;
-
   final uri =
       Uri.parse('https://example.test/s/opentelemetry-collector/v1/traces');
 
-  setUp(() {
-    mockClient = MockHttpClient();
-  });
+  group('Send spans with success - ', () {
+    late MockHttpClient mockClient;
+    setUp(() {
+      mockClient = MockHttpClient();
+      when(() => mockClient.post(uri,
+              body: any(named: 'body'), headers: any(named: 'headers')))
+          .thenAnswer((_) async => Response('', 200));
+    });
 
-  tearDown(() {
-    reset(mockClient);
-  });
+    tearDown(() {
+      reset(mockClient);
+    });
 
-  test('sends spans', () {
-    final resource =
-        sdk.Resource([api.Attribute.fromString('service.name', 'bar')]);
-    final instrumentationLibrary = sdk.InstrumentationScope(
-        'library_name', 'library_version', 'url://schema', []);
-    final limits = sdk.SpanLimits(maxNumAttributeLength: 5);
-    final span1 = Span(
-        'foo',
-        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, api.TraceState.empty()),
-        api.SpanId([4, 5, 6]),
-        [],
-        sdk.DateTimeTimeProvider(),
-        resource,
-        instrumentationLibrary,
-        api.SpanKind.client,
-        [],
-        sdk.SpanLimits(),
-        sdk.DateTimeTimeProvider().now)
-      ..setAttributes([api.Attribute.fromString('foo', 'bar')])
-      ..end();
-    final span2 = Span(
-        'baz',
-        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([10, 11, 12]),
-            api.TraceFlags.none, api.TraceState.empty()),
-        api.SpanId([4, 5, 6]),
-        [],
-        sdk.DateTimeTimeProvider(),
-        resource,
-        instrumentationLibrary,
-        api.SpanKind.internal,
-        applyLinkLimits([
-          api.SpanLink(span1.spanContext, attributes: [
-            api.Attribute.fromString('longKey',
-                'I am very long with maxNumAttributeLength: 5 limitation!')
-          ]),
-        ], limits),
-        limits,
-        sdk.DateTimeTimeProvider().now)
-      ..setAttributes([api.Attribute.fromBoolean('bool', true)])
-      ..addEvent('testEvent',
-          timestamp: sdk.DateTimeTimeProvider().now,
-          attributes: [api.Attribute.fromString('foo', 'bar')])
-      ..end();
+    test('sends spans', () async {
+      final resource =
+          sdk.Resource([api.Attribute.fromString('service.name', 'bar')]);
+      final instrumentationLibrary = sdk.InstrumentationScope(
+          'library_name', 'library_version', 'url://schema', []);
+      final limits = sdk.SpanLimits(maxNumAttributeLength: 5);
+      final span1 = Span(
+          'foo',
+          api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+              api.TraceFlags.none, api.TraceState.empty()),
+          api.SpanId([4, 5, 6]),
+          [],
+          sdk.DateTimeTimeProvider(),
+          resource,
+          instrumentationLibrary,
+          api.SpanKind.client,
+          [],
+          sdk.SpanLimits(),
+          sdk.DateTimeTimeProvider().now)
+        ..setAttributes([api.Attribute.fromString('foo', 'bar')])
+        ..end();
+      final span2 = Span(
+          'baz',
+          api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([10, 11, 12]),
+              api.TraceFlags.none, api.TraceState.empty()),
+          api.SpanId([4, 5, 6]),
+          [],
+          sdk.DateTimeTimeProvider(),
+          resource,
+          instrumentationLibrary,
+          api.SpanKind.internal,
+          applyLinkLimits([
+            api.SpanLink(span1.spanContext, attributes: [
+              api.Attribute.fromString('longKey',
+                  'I am very long with maxNumAttributeLength: 5 limitation!')
+            ]),
+          ], limits),
+          limits,
+          sdk.DateTimeTimeProvider().now)
+        ..setAttributes([api.Attribute.fromBoolean('bool', true)])
+        ..addEvent('testEvent',
+            timestamp: sdk.DateTimeTimeProvider().now,
+            attributes: [api.Attribute.fromString('foo', 'bar')])
+        ..end();
 
-    sdk.CollectorExporter(uri, httpClient: mockClient).export([span1, span2]);
+      await sdk.CollectorExporter(uri, httpClient: mockClient)
+          .export([span1, span2]);
 
-    final expectedBody =
-        pb_trace_service.ExportTraceServiceRequest(resourceSpans: [
-      pb.ResourceSpans(
-          resource: pb_resource.Resource(attributes: [
-            pb_common.KeyValue(
-                key: 'service.name',
-                value: pb_common.AnyValue(stringValue: 'bar'))
-          ]),
-          scopeSpans: [
-            pb.ScopeSpans(
-                spans: [
-                  pb.Span(
-                      traceId: [1, 2, 3],
-                      spanId: [7, 8, 9],
-                      traceState: '',
-                      parentSpanId: [4, 5, 6],
-                      name: 'foo',
-                      kind: pb.Span_SpanKind.SPAN_KIND_CLIENT,
-                      startTimeUnixNano: span1.startTime,
-                      endTimeUnixNano: span1.endTime,
-                      attributes: [
-                        pb_common.KeyValue(
-                            key: 'foo',
-                            value: pb_common.AnyValue(stringValue: 'bar'))
-                      ],
-                      droppedAttributesCount: 0,
-                      status: pb.Status(
-                          code: pb.Status_StatusCode.STATUS_CODE_UNSET,
-                          message: ''),
-                      flags: 0),
-                  pb.Span(
-                      traceId: [1, 2, 3],
-                      spanId: [10, 11, 12],
-                      traceState: '',
-                      parentSpanId: [4, 5, 6],
-                      name: 'baz',
-                      kind: pb.Span_SpanKind.SPAN_KIND_INTERNAL,
-                      startTimeUnixNano: span2.startTime,
-                      endTimeUnixNano: span2.endTime,
-                      attributes: [
-                        pb_common.KeyValue(
-                            key: 'bool',
-                            value: pb_common.AnyValue(boolValue: true))
-                      ],
-                      droppedAttributesCount: 0,
-                      events: [
-                        pb.Span_Event(
-                          timeUnixNano: span2.events.first.timestamp,
-                          name: 'testEvent',
-                          attributes: [
-                            pb_common.KeyValue(
-                                key: 'foo',
-                                value: pb_common.AnyValue(stringValue: 'bar'))
-                          ],
-                          droppedAttributesCount: 0,
-                        )
-                      ],
-                      droppedEventsCount: 0,
-                      status: pb.Status(
-                          code: pb.Status_StatusCode.STATUS_CODE_UNSET,
-                          message: ''),
-                      links: [
-                        pb.Span_Link(
-                            traceId: [1, 2, 3],
-                            spanId: [7, 8, 9],
-                            traceState: '',
+      final expectedBody =
+          pb_trace_service.ExportTraceServiceRequest(resourceSpans: [
+        pb.ResourceSpans(
+            resource: pb_resource.Resource(attributes: [
+              pb_common.KeyValue(
+                  key: 'service.name',
+                  value: pb_common.AnyValue(stringValue: 'bar'))
+            ]),
+            scopeSpans: [
+              pb.ScopeSpans(
+                  spans: [
+                    pb.Span(
+                        traceId: [1, 2, 3],
+                        spanId: [7, 8, 9],
+                        traceState: '',
+                        parentSpanId: [4, 5, 6],
+                        name: 'foo',
+                        kind: pb.Span_SpanKind.SPAN_KIND_CLIENT,
+                        startTimeUnixNano: span1.startTime,
+                        endTimeUnixNano: span1.endTime,
+                        attributes: [
+                          pb_common.KeyValue(
+                              key: 'foo',
+                              value: pb_common.AnyValue(stringValue: 'bar'))
+                        ],
+                        droppedAttributesCount: 0,
+                        status: pb.Status(
+                            code: pb.Status_StatusCode.STATUS_CODE_UNSET,
+                            message: ''),
+                        flags: 0),
+                    pb.Span(
+                        traceId: [1, 2, 3],
+                        spanId: [10, 11, 12],
+                        traceState: '',
+                        parentSpanId: [4, 5, 6],
+                        name: 'baz',
+                        kind: pb.Span_SpanKind.SPAN_KIND_INTERNAL,
+                        startTimeUnixNano: span2.startTime,
+                        endTimeUnixNano: span2.endTime,
+                        attributes: [
+                          pb_common.KeyValue(
+                              key: 'bool',
+                              value: pb_common.AnyValue(boolValue: true))
+                        ],
+                        droppedAttributesCount: 0,
+                        events: [
+                          pb.Span_Event(
+                            timeUnixNano: span2.events.first.timestamp,
+                            name: 'testEvent',
                             attributes: [
                               pb_common.KeyValue(
-                                  key: 'longKey',
-                                  value:
-                                      pb_common.AnyValue(stringValue: 'I am '))
+                                  key: 'foo',
+                                  value: pb_common.AnyValue(stringValue: 'bar'))
                             ],
                             droppedAttributesCount: 0,
-                            flags: 0)
-                      ],
-                      droppedLinksCount: 0,
-                      flags: 0)
-                ],
-                scope: pb_common.InstrumentationScope(
-                    name: 'library_name', version: 'library_version'))
-          ])
-    ]);
+                          )
+                        ],
+                        droppedEventsCount: 0,
+                        status: pb.Status(
+                            code: pb.Status_StatusCode.STATUS_CODE_UNSET,
+                            message: ''),
+                        links: [
+                          pb.Span_Link(
+                              traceId: [1, 2, 3],
+                              spanId: [7, 8, 9],
+                              traceState: '',
+                              attributes: [
+                                pb_common.KeyValue(
+                                    key: 'longKey',
+                                    value: pb_common.AnyValue(
+                                        stringValue: 'I am '))
+                              ],
+                              droppedAttributesCount: 0,
+                              flags: 0)
+                        ],
+                        droppedLinksCount: 0,
+                        flags: 0)
+                  ],
+                  scope: pb_common.InstrumentationScope(
+                      name: 'library_name', version: 'library_version'))
+            ])
+      ]);
 
-    final verifyResult = verify(() => mockClient.post(uri,
-        body: captureAny(named: 'body'),
-        headers: {'Content-Type': 'application/x-protobuf'}))
-      ..called(1);
-    final captured = verifyResult.captured;
+      final verifyResult = verify(() => mockClient.post(uri,
+          body: captureAny(named: 'body'),
+          headers: {'Content-Type': 'application/x-protobuf'}))
+        ..called(1);
+      final captured = verifyResult.captured;
 
-    final traceRequest = pb_trace_service.ExportTraceServiceRequest.fromBuffer(
-        captured[0] as Uint8List);
-    expect(traceRequest, equals(expectedBody));
+      final traceRequest =
+          pb_trace_service.ExportTraceServiceRequest.fromBuffer(
+              captured[0] as Uint8List);
+      expect(traceRequest, equals(expectedBody));
+    });
+
+    test('does not send spans when shutdown', () async {
+      final span = Span(
+          'foo',
+          api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+              api.TraceFlags.none, api.TraceState.empty()),
+          api.SpanId([4, 5, 6]),
+          [],
+          sdk.DateTimeTimeProvider(),
+          sdk.Resource([]),
+          sdk.InstrumentationScope(
+              'library_name', 'library_version', 'url://schema', []),
+          api.SpanKind.internal,
+          [],
+          sdk.SpanLimits(),
+          sdk.DateTimeTimeProvider().now)
+        ..end();
+      final exporter = sdk.CollectorExporter(uri, httpClient: mockClient);
+      // ignore: cascade_invocations
+      exporter.shutdown();
+      await exporter.export([span]);
+
+      verify(() => mockClient.close()).called(1);
+      verifyNever(() => mockClient.post(uri,
+          body: anything, headers: {'Content-Type': 'application/x-protobuf'}));
+    });
+
+    test('supplies HTTP headers', () async {
+      final span = Span(
+          'foo',
+          api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+              api.TraceFlags.none, api.TraceState.empty()),
+          api.SpanId([4, 5, 6]),
+          [],
+          sdk.DateTimeTimeProvider(),
+          sdk.Resource([]),
+          sdk.InstrumentationScope(
+              'library_name', 'library_version', 'url://schema', []),
+          api.SpanKind.internal,
+          [],
+          sdk.SpanLimits(),
+          sdk.DateTimeTimeProvider().now)
+        ..end();
+
+      final suppliedHeaders = {
+        'header-param-key-1': 'header-param-value-1',
+        'header-param-key-2': 'header-param-value-2',
+      };
+      final expectedHeaders = {
+        'Content-Type': 'application/x-protobuf',
+        ...suppliedHeaders,
+      };
+
+      await sdk.CollectorExporter(uri,
+              httpClient: mockClient, headers: suppliedHeaders)
+          .export([span]);
+
+      verify(() =>
+              mockClient.post(uri, body: anything, headers: expectedHeaders))
+          .called(1);
+    });
+
+    test('does not supply HTTP headers', () async {
+      final span = Span(
+          'foo',
+          api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+              api.TraceFlags.none, api.TraceState.empty()),
+          api.SpanId([4, 5, 6]),
+          [],
+          sdk.DateTimeTimeProvider(),
+          sdk.Resource([]),
+          sdk.InstrumentationScope(
+              'library_name', 'library_version', 'url://schema', []),
+          api.SpanKind.internal,
+          [],
+          sdk.SpanLimits(),
+          sdk.DateTimeTimeProvider().now)
+        ..end();
+
+      final expectedHeaders = {'Content-Type': 'application/x-protobuf'};
+
+      await sdk.CollectorExporter(uri, httpClient: mockClient).export([span]);
+
+      verify(() =>
+              mockClient.post(uri, body: anything, headers: expectedHeaders))
+          .called(1);
+    });
   });
 
-  test('shows a warning log when export failed', () {
-    final span = Span(
-        'foo',
-        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, api.TraceState.empty()),
-        api.SpanId([4, 5, 6]),
-        [],
-        sdk.DateTimeTimeProvider(),
-        sdk.Resource([]),
-        sdk.InstrumentationScope(
-            'library_name', 'library_version', 'url://schema', []),
-        api.SpanKind.internal,
-        [],
-        sdk.SpanLimits(),
-        sdk.DateTimeTimeProvider().now)
-      ..end();
+  group('Send spans with failure - ', () {
+    late MockHttpClient mockClient;
+    setUp(() {
+      mockClient = MockHttpClient();
+      when(() => mockClient.post(uri,
+              body: any(named: 'body'), headers: any(named: 'headers')))
+          .thenAnswer((_) async => Response('', 403));
+    });
 
-    when(() => mockClient.post(uri,
-            body: any(named: 'body'),
-            headers: {'Content-Type': 'application/x-protobuf'}))
-        .thenThrow(Exception('Failed to connect'));
+    tearDown(() {
+      reset(mockClient);
+    });
+    test('shows a warning log when export failed', () async {
+      final span = Span(
+          'foo',
+          api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+              api.TraceFlags.none, api.TraceState.empty()),
+          api.SpanId([4, 5, 6]),
+          [],
+          sdk.DateTimeTimeProvider(),
+          sdk.Resource([]),
+          sdk.InstrumentationScope(
+              'library_name', 'library_version', 'url://schema', []),
+          api.SpanKind.internal,
+          [],
+          sdk.SpanLimits(),
+          sdk.DateTimeTimeProvider().now)
+        ..end();
 
-    final records = <LogRecord>[];
-    final sub = Logger.root.onRecord.listen(records.add);
-    sdk.CollectorExporter(uri, httpClient: mockClient).export([span]);
-    sub.cancel();
+      when(() => mockClient.post(uri,
+              body: any(named: 'body'),
+              headers: {'Content-Type': 'application/x-protobuf'}))
+          .thenThrow(Exception('Failed to connect'));
 
-    verify(() => mockClient.post(uri,
-        body: anything,
-        headers: {'Content-Type': 'application/x-protobuf'})).called(3);
+      final records = <LogRecord>[];
+      final sub = Logger.root.onRecord.listen(records.add);
+      await sdk.CollectorExporter(uri, httpClient: mockClient).export([span]);
+      await sub.cancel();
 
-    expect(records, hasLength(4));
-    expect(records[0].level, equals(Level.WARNING));
-    expect(records[3].level, equals(Level.SEVERE));
-  });
+      verify(() => mockClient.post(uri,
+          body: anything,
+          headers: {'Content-Type': 'application/x-protobuf'})).called(3);
 
-  test('does not send spans when shutdown', () {
-    final span = Span(
-        'foo',
-        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, api.TraceState.empty()),
-        api.SpanId([4, 5, 6]),
-        [],
-        sdk.DateTimeTimeProvider(),
-        sdk.Resource([]),
-        sdk.InstrumentationScope(
-            'library_name', 'library_version', 'url://schema', []),
-        api.SpanKind.internal,
-        [],
-        sdk.SpanLimits(),
-        sdk.DateTimeTimeProvider().now)
-      ..end();
+      expect(records, hasLength(4));
+      expect(records[0].level, equals(Level.WARNING));
+      expect(records[1].level, equals(Level.WARNING));
+      expect(records[2].level, equals(Level.WARNING));
+      expect(records[3].level, equals(Level.SEVERE));
+    });
 
-    sdk.CollectorExporter(uri, httpClient: mockClient)
-      ..shutdown()
-      ..export([span]);
+    test('client not return 200', () async {
+      final span = Span(
+          'foo',
+          api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
+              api.TraceFlags.none, api.TraceState.empty()),
+          api.SpanId([4, 5, 6]),
+          [],
+          sdk.DateTimeTimeProvider(),
+          sdk.Resource([]),
+          sdk.InstrumentationScope(
+              'library_name', 'library_version', 'url://schema', []),
+          api.SpanKind.internal,
+          [],
+          sdk.SpanLimits(),
+          sdk.DateTimeTimeProvider().now)
+        ..end();
 
-    verify(() => mockClient.close()).called(1);
-    verifyNever(() => mockClient.post(uri,
-        body: anything, headers: {'Content-Type': 'application/x-protobuf'}));
-  });
+      when(() => mockClient.post(uri,
+              body: any(named: 'body'),
+              headers: {'Content-Type': 'application/x-protobuf'}))
+          .thenAnswer((_) async => Response('Service unAvailable', 403));
 
-  test('supplies HTTP headers', () {
-    final span = Span(
-        'foo',
-        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, api.TraceState.empty()),
-        api.SpanId([4, 5, 6]),
-        [],
-        sdk.DateTimeTimeProvider(),
-        sdk.Resource([]),
-        sdk.InstrumentationScope(
-            'library_name', 'library_version', 'url://schema', []),
-        api.SpanKind.internal,
-        [],
-        sdk.SpanLimits(),
-        sdk.DateTimeTimeProvider().now)
-      ..end();
+      final expectedHeaders = {'Content-Type': 'application/x-protobuf'};
+      await sdk.CollectorExporter(uri, httpClient: mockClient).export([span]);
 
-    final suppliedHeaders = {
-      'header-param-key-1': 'header-param-value-1',
-      'header-param-key-2': 'header-param-value-2',
-    };
-    final expectedHeaders = {
-      'Content-Type': 'application/x-protobuf',
-      ...suppliedHeaders,
-    };
-
-    sdk.CollectorExporter(uri, httpClient: mockClient, headers: suppliedHeaders)
-        .export([span]);
-
-    verify(() => mockClient.post(uri, body: anything, headers: expectedHeaders))
-        .called(1);
-  });
-
-  test('does not supply HTTP headers', () {
-    final span = Span(
-        'foo',
-        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, api.TraceState.empty()),
-        api.SpanId([4, 5, 6]),
-        [],
-        sdk.DateTimeTimeProvider(),
-        sdk.Resource([]),
-        sdk.InstrumentationScope(
-            'library_name', 'library_version', 'url://schema', []),
-        api.SpanKind.internal,
-        [],
-        sdk.SpanLimits(),
-        sdk.DateTimeTimeProvider().now)
-      ..end();
-
-    final expectedHeaders = {'Content-Type': 'application/x-protobuf'};
-
-    sdk.CollectorExporter(uri, httpClient: mockClient).export([span]);
-
-    verify(() => mockClient.post(uri, body: anything, headers: expectedHeaders))
-        .called(1);
-  });
-
-  test('client not return 200', () {
-    final span = Span(
-        'foo',
-        api.SpanContext(api.TraceId([1, 2, 3]), api.SpanId([7, 8, 9]),
-            api.TraceFlags.none, api.TraceState.empty()),
-        api.SpanId([4, 5, 6]),
-        [],
-        sdk.DateTimeTimeProvider(),
-        sdk.Resource([]),
-        sdk.InstrumentationScope(
-            'library_name', 'library_version', 'url://schema', []),
-        api.SpanKind.internal,
-        [],
-        sdk.SpanLimits(),
-        sdk.DateTimeTimeProvider().now)
-      ..end();
-
-    when(() => mockClient.post(uri,
-            body: any(named: 'body'),
-            headers: {'Content-Type': 'application/x-protobuf'}))
-        .thenAnswer((_) async => Response('Service unAvailable', 403));
-
-    final expectedHeaders = {'Content-Type': 'application/x-protobuf'};
-    sdk.CollectorExporter(uri, httpClient: mockClient).export([span]);
-
-    verify(() => mockClient.post(uri, body: anything, headers: expectedHeaders))
-        .called(3);
+      verify(() =>
+              mockClient.post(uri, body: anything, headers: expectedHeaders))
+          .called(3);
+    });
   });
 }

--- a/test/unit/sdk/exporters/collector_exporter_test.dart
+++ b/test/unit/sdk/exporters/collector_exporter_test.dart
@@ -271,7 +271,7 @@ void main() {
 
   group('Send spans with failure - ', () {
     late MockHttpClient mockClient;
-    final waitSeconds = Duration(seconds: 10);
+    final waitSeconds = Duration(seconds: 2);
     setUp(() {
       mockClient = MockHttpClient();
       when(() => mockClient.post(uri,
@@ -307,7 +307,7 @@ void main() {
       final records = <LogRecord>[];
       final sub = Logger.root.onRecord.listen(records.add);
       sdk.CollectorExporter(uri, httpClient: mockClient).export([span]);
-      await Future.delayed(Duration(seconds: 5));
+      await Future.delayed(waitSeconds);
       await sub.cancel();
       verify(() => mockClient.post(uri,
           body: anything,


### PR DESCRIPTION
## Which problem is this PR solving?

When call [client.post](https://github.com/Workiva/opentelemetry-dart/blob/master/lib/src/sdk/trace/exporters/collector_exporter.dart#L54) collector_exporter didn't check if the response is succeeded or not, this PR would like to add retry effort when the response is retryable. 


## Short description of the change


## How Has This Been Tested?

Please describe the tests that you ran to verify your change. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Checklist:

- [x] Unit tests have been added
- [ ] Documentation has been updated