### PR TITLE
feat: set meta version in range for flutter 3.10.0 (dart 3.0.0)  and above

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   fixnum: '>=1.0.0 <2.0.0'
   http: '>=0.13.0 <2.0.0'
   logging: ^1.0.0
-  meta: ^1.16.0
+  meta: '>=1.9.1 <2.0.0'
   protobuf: '>=2.0.0 <4.0.0'
   quiver: '>=3.0.0 <4.0.0'
 


### PR DESCRIPTION
## Which problem is this PR solving?
1. Define version range to follow version pinning for Flutter https://dart.dev/go/sdk-version-pinning

close https://github.com/Workiva/opentelemetry-dart/issues/201

## Short description of the change
1. Set `meta` version to be of range between 1.9.1 and 2.0.0 which covers all flutter version what is running with Dart 3.0 until latest

## How Has This Been Tested?
1. Add package in flutter project.
2. Run `flutter packages get`.


## Checklist:

- [ ] Unit tests have been added
- [ ] Documentation has been updated