### PR TITLE
Fix trace and traceSync not creating root spans when newRoot is true

### DIFF
--- a/lib/src/api/open_telemetry.dart
+++ b/lib/src/api/open_telemetry.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import '../../api.dart' as api;
+import '../../src/sdk/trace/tracer.dart' as sdk show Tracer;
 import '../experimental_api.dart';
 import 'propagation/noop_text_map_propagator.dart';
 import 'trace/noop_tracer_provider.dart';
@@ -102,12 +103,23 @@ Future<T> trace<T>(String name, Future<T> Function() fn,
   context ??= api.Context.current;
   tracer ??= _tracerProvider.getTracer('opentelemetry-dart');
 
-  final span = tracer.startSpan(name,
-      // TODO: use start span option `newRoot` instead
-      context: newRoot ? api.Context.root : context,
-      attributes: spanAttributes,
-      kind: spanKind,
-      links: spanLinks);
+  // TODO: use start span option `newRoot` instead
+  var span;
+  if (tracer is sdk.Tracer) {
+    span = tracer.startSpan(name,
+        context: context,
+        attributes: spanAttributes,
+        kind: spanKind,
+        links: spanLinks,
+        newRoot: newRoot);
+  } else {
+    span = tracer.startSpan(name,
+        context: newRoot ? api.Context.root : context,
+        attributes: spanAttributes,
+        kind: spanKind,
+        links: spanLinks);
+  }
+
   try {
     return await Zone.current.fork().run(() {
       final token = api.Context.attach(api.contextWithSpan(context!, span));
@@ -139,12 +151,23 @@ T traceSync<T>(String name, T Function() fn,
   context ??= api.Context.current;
   tracer ??= _tracerProvider.getTracer('opentelemetry-dart');
 
-  final span = tracer.startSpan(name,
-      // TODO: use start span option `newRoot` instead
-      context: newRoot ? api.Context.root : context,
-      attributes: spanAttributes,
-      kind: spanKind,
-      links: spanLinks);
+  // TODO: use start span option `newRoot` instead
+  var span;
+  if (tracer is sdk.Tracer) {
+    span = tracer.startSpan(name,
+        context: context,
+        attributes: spanAttributes,
+        kind: spanKind,
+        links: spanLinks,
+        newRoot: newRoot);
+  } else {
+    span = tracer.startSpan(name,
+        context: newRoot ? api.Context.root : context,
+        attributes: spanAttributes,
+        kind: spanKind,
+        links: spanLinks);
+  }
+
   try {
     return Zone.current.fork().run(() {
       final token = api.Context.attach(api.contextWithSpan(context!, span));

--- a/test/api/open_telemetry_test.dart
+++ b/test/api/open_telemetry_test.dart
@@ -58,6 +58,32 @@ void main() {
     }, tracer: tracer, context: contextWithSpan(Context.current, parent));
   });
 
+  test('trace creates a root span', () async {
+    final parent = tracer.startSpan('parent')..end();
+    final context = contextWithSpan(Context.current, parent);
+    final token = Context.attach(context);
+
+    await trace('child', () async {
+      final child = spanFromContext(Context.current);
+      expect(child.parentSpanId.isValid, isFalse);
+    }, tracer: tracer, context: context, newRoot: true);
+
+    Context.detach(token);
+  });
+
+  test('traceSync creates a root span', () {
+    final parent = tracer.startSpan('parent')..end();
+    final context = contextWithSpan(Context.current, parent);
+    final token = Context.attach(context);
+
+    traceSync('child', () {
+      final child = spanFromContext(Context.current);
+      expect(child.parentSpanId.isValid, isFalse);
+    }, tracer: tracer, context: context, newRoot: true);
+
+    Context.detach(token);
+  });
+
   test('trace catches, records, and rethrows exception', () async {
     late sdk.Span span;
     var caught = false;


### PR DESCRIPTION
## Which problem is this PR solving?

`trace` and `traceSync` have a `newRoot` optional parameter that works by using `Context.root` to start the span. However, if there is a context with a span attached to the root zone, then using `Context.root` will make the span a child of the one held by the context attached to the root zone.

## Short description of the change

The `Tracer` defined by the SDK supports the `newRoot` optional parameter that results in appropriately configuring the span's parent span context to be invalid regardless of any span potentially visible via the given context.

However, the `Tracer` defined by the API does not support the `newRoot` optional parameter. Ideally, this interface would be updated to include the optional parameter. But this is a breaking change.

Therefore, to resolve the issue of `newRoot` not creating root spans, `trace` and `traceSync` type check the `tracer` to see if it is the SDK's `Tracer`. If so, the tracer's `newRoot` option is used. Otherwise, the API's `tracer` is used as usual.

## How Has This Been Tested?

The unit tests added in this PR were ran with and without the changes. Without the changes, the unit tests fail. With the changes, the unit tests pass.


## Checklist:

- [x] Unit tests have been added
- [ ] Documentation has been updated