### PR TITLE
Fix Tracer.startSpan signature

### DIFF
--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -17,9 +17,10 @@ abstract class Tracer {
   /// The [api.Span] is created with the provided name and as a child of any
   /// existing span context found in the passed context.
   api.Span startSpan(String name,
-      {api.Context context,
-      api.SpanKind kind,
-      List<api.Attribute> attributes,
-      List<api.SpanLink> links,
-      Int64 startTime});
+      {api.Context? context,
+      api.SpanKind kind = api.SpanKind.internal,
+      List<api.Attribute> attributes = const [],
+      List<api.SpanLink> links = const [],
+      Int64? startTime,
+      bool newRoot = false});
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Inconsistency between implementation (SDK) and interface (API) of `Tracer.startSpan`.

## Short description of the change

Ensures that the API's `Tracer.startSpan` signature matches that in the implementation.

## How Has This Been Tested?

Running all tests again with the change made.


## Checklist:

(I don't think either is relevant, but happy to discuss)

- [ ] Unit tests have been added
- [ ] Documentation has been updated