### PR TITLE
no_entrypoint_imports

### DIFF
--- a/lib/src/api/logs/logger_provider.dart
+++ b/lib/src/api/logs/logger_provider.dart
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import 'package:opentelemetry/api.dart';
+
 import 'package:opentelemetry/src/api/logs/logger.dart';
 
 abstract class LoggerProvider {

--- a/lib/src/api/metrics/counter.dart
+++ b/lib/src/api/metrics/counter.dart
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import 'package:opentelemetry/api.dart';
+
 
 abstract class Counter<T extends num> {
   /// Records a value with a set of attributes.

--- a/lib/src/api/metrics/meter_key.dart
+++ b/lib/src/api/metrics/meter_key.dart
@@ -3,7 +3,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:quiver/core.dart';
-import 'package:opentelemetry/api.dart';
+
 
 /// A class that acts as a unique key for a given Meter configuration.
 class MeterKey {

--- a/lib/src/api/metrics/meter_provider.dart
+++ b/lib/src/api/metrics/meter_provider.dart
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import 'package:opentelemetry/api.dart';
+
 import 'package:opentelemetry/src/experimental_api.dart';
 
 /// A registry for creating named [Meter]s.

--- a/lib/src/api/metrics/noop/noop_counter.dart
+++ b/lib/src/api/metrics/noop/noop_counter.dart
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import 'package:opentelemetry/api.dart';
+
 import 'package:opentelemetry/src/experimental_api.dart';
 
 /// A no-op instance of a [Counter]

--- a/lib/src/api/metrics/noop/noop_meter_provider.dart
+++ b/lib/src/api/metrics/noop/noop_meter_provider.dart
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import 'package:opentelemetry/api.dart';
+
 import 'package:opentelemetry/src/experimental_api.dart';
 
 /// A noop registry for creating named [Meter]s.

--- a/lib/src/sdk/common/instrumentation_scope.dart
+++ b/lib/src/sdk/common/instrumentation_scope.dart
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import 'package:opentelemetry/api.dart' as api;
+
 
 class InstrumentationScope {
   final String _name;

--- a/lib/src/sdk/metrics/counter.dart
+++ b/lib/src/sdk/metrics/counter.dart
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import 'package:opentelemetry/api.dart' as api;
+
 import 'package:opentelemetry/src/experimental_api.dart' as api;
 
 class Counter<T extends num> implements api.Counter<T> {

--- a/lib/src/sdk/trace/read_write_span.dart
+++ b/lib/src/sdk/trace/read_write_span.dart
@@ -1,7 +1,7 @@
 // Copyright 2021-2022 Workiva.
 // Licensed under the Apache License, Version 2.0. Please see https://github.com/Workiva/opentelemetry-dart/blob/master/LICENSE for more information
 
-import 'package:opentelemetry/api.dart' as api;
-import 'package:opentelemetry/sdk.dart' as sdk;
+
+
 
 abstract class ReadWriteSpan implements sdk.ReadOnlySpan, api.Span {}

--- a/lib/src/sdk/trace/span.dart
+++ b/lib/src/sdk/trace/span.dart
@@ -3,7 +3,7 @@
 
 import 'package:fixnum/fixnum.dart';
 import 'package:meta/meta.dart';
-import 'package:opentelemetry/api.dart';
+
 
 import '../../../api.dart' as api;
 import '../../../sdk.dart' as sdk;


### PR DESCRIPTION
## Problem

An entrypoint import can be defined as an import within `lib/src` that imports a file within `lib/*.dart` (the entrypoints of a dart package). These imports are always unnecessary, and can contribute to slower dart build performance.

## Solution

This PR naively removes every entrypoint import within the repo, and updates the `gha-dart/.../checks.yaml` to the latest version. In order to merge this PR a few manual changes must be performed:

- Navigate to every file which has analysis errors caused from the missing import. Rely on intellisense to import the necessary symbol from the specific file, not the entrypoint import
- Implement the `no_entrypoint_imports` additional-checks option in `gha-dart@v2.10.13` that was added in [this PR](https://github.com/Workiva/gha-dart/pull/716). This will prevent new entrypoint imports from getting added once this PR merges

Our request to teams is to perform the above tasks, so we can default enable the `no_entrypoint_imports` check for all gha-dart consumers. Please reach out to [#support-frontend-dx](https://workiva.enterprise.slack.com/archives/C03ESR91BNU) for any questions or issues

## QA

- [ ] This pr is heavily dependant on the analysis server, and as such CI passes should be sufficient

[_Created by Sourcegraph batch change `Workiva/no_entrypoint_imports`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/no_entrypoint_imports)