### PR TITLE
Fix master CI

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 3.9
-      - run: sudo apt install -y protobuf-compiler
+      - run: sudo apt-get update && sudo apt-get install -y --fix-missing protobuf-compiler
       - run: make init format analyze test
       - name: Generate Coverage
         run: dart test --coverage=./coverage
@@ -50,5 +50,5 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
-      - run: sudo apt install -y protobuf-compiler
+      - run: sudo apt-get update && sudo apt-get install -y --fix-missing protobuf-compiler
       - run: make init format analyze test


### PR DESCRIPTION
This pull request updates the setup steps in the Dart CI workflow to improve the reliability of installing the `protobuf-compiler` package. The installation command now includes an update and a fix for missing dependencies, which helps prevent CI failures due to package issues.
