### PR TITLE
FEA-11205: Fix zone() duplicate context attaches via zoneValues propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- **Fix:** `zone()` no longer attaches a duplicate context on every internal
+  `Zone.run` invocation (microtasks, timers, `Future.whenComplete`,
+  `bindCallback`, `runGuarded`). It now propagates the context via the forked
+  zone's `zoneValues` map, eliminating spurious
+  `unexpected (mismatched) token given to detach` warnings.
+- **New:** `runInContext` for `zoneValues`-based context propagation. Prefer
+  this (or `zone()`) over `Context.attach` / `Context.detach` when scoping a
+  `Context` to an asynchronous region.
+- **Behavior change (minor):** when both a `zoneValues` context and a
+  stack-attached context coexist in the same zone, the `zoneValues` context now
+  wins. Previously the stack-attached context won.
+
 ## [0.18.6](https://github.com/Workiva/opentelemetry-dart/tree/0.18.6) (2024-08-15)
 
 [Full Changelog](https://github.com/Workiva/opentelemetry-dart/compare/0.18.5...0.18.6)

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -10,6 +10,7 @@ export 'src/api/context/context.dart'
         ContextKey,
         contextWithSpan,
         contextWithSpanContext,
+        runInContext,
         spanContextFromContext,
         spanFromContext,
         zone;

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -34,6 +34,15 @@ class ContextStackEntry {
 final _rootContext = Context._empty();
 final _stacks = <Zone, List<ContextStackEntry>>{Zone.root: []};
 
+/// Zone value key used to propagate the active [Context] via the forked zone's
+/// `zoneValues` map.
+///
+/// This is an internal implementation detail of [zone] / [runInContext]. It
+/// avoids the global per-zone attach stack entirely, so it can't be disturbed
+/// by other concurrent attaches, misordered detaches, or zone-bound
+/// microtasks.
+final Object _contextZoneKey = Object();
+
 Context contextWithSpan(Context parent, Span span) {
   return parent.setValue(_spanKey, span);
 }
@@ -50,31 +59,23 @@ SpanContext spanContextFromContext(Context context) {
   return spanFromContext(context).spanContext;
 }
 
-/// Returns a new [Zone] such that the given context will be automatically
-/// attached and detached for any function that runs within the zone.
+/// Returns a new [Zone] such that the given context will be visible to
+/// [Context.current] for any function that runs within the zone.
+///
+/// The context is propagated via the forked zone's `zoneValues` map rather than
+/// via [Context.attach] / [Context.detach]. This avoids attaching a duplicate
+/// context on every internal `Zone.run` invocation (microtasks, timers,
+/// `Future.whenComplete`, etc.).
 @experimental
 Zone zone([Context? context]) => Zone.current.fork(
-  specification: ZoneSpecification(
-    run: <R>(self, parent, zone, fn) {
-      // Only attach the context when delegating this zone's run, not any
-      // potential child. Otherwise, the child zone's current context would
-      // end up being the outermost zone attached context.
-      if (self == zone) {
-        final token = Context.attach(context ?? _currentContext(zone), zone);
-        final result = parent.run(zone, fn);
-        if (result is Future) {
-          result.whenComplete(() {
-            Context.detach(token, zone);
-          });
-        } else {
-          Context.detach(token, zone);
-        }
-        return result;
-      }
-      return parent.run(zone, fn);
-    },
-  ),
+  zoneValues: {_contextZoneKey: context ?? _currentContext()},
 );
+
+/// Runs [body] within a new [Zone] in which [Context.current] returns
+/// [context]. Returns whatever [body] returns.
+@experimental
+R runInContext<R>(Context context, R Function() body) =>
+    runZoned(body, zoneValues: {_contextZoneKey: context});
 
 /// Returns the latest non-empty context stack, or the root stack if no context
 /// stack is found.
@@ -92,9 +93,18 @@ List<ContextStackEntry> _currentContextStack(Zone zone) {
   return stack;
 }
 
-Context _currentContext([Zone? zone]) =>
-    _currentContextStack(zone ?? Zone.current).lastOrNull?.context ??
-    _rootContext;
+Context _currentContext([Zone? zone]) {
+  final effectiveZone = zone ?? Zone.current;
+  // Prefer a context propagated via `zoneValues` (see [_contextZoneKey]).
+  // Dart walks this lookup up the zone tree, so a context set in any ancestor
+  // zone is visible here.
+  final fromZone = effectiveZone[_contextZoneKey];
+  if (fromZone is Context) {
+    return fromZone;
+  }
+  return _currentContextStack(effectiveZone).lastOrNull?.context ??
+      _rootContext;
+}
 
 class Context {
   final Context? _parent;

--- a/test/api/context/context_test.dart
+++ b/test/api/context/context_test.dart
@@ -210,5 +210,19 @@ void main() {
         api.Context.detach(token);
       });
     });
+
+    test('nested zone() calls shadow outer context and restore on exit', () {
+      final myKey = api.ContextKey();
+      final outerCtx = api.Context.current.setValue(myKey, 'outer');
+      final innerCtx = api.Context.current.setValue(myKey, 'inner');
+      api.zone(outerCtx).run(() {
+        expect(api.Context.current.getValue<String>(myKey), 'outer');
+        api.zone(innerCtx).run(() {
+          expect(api.Context.current.getValue<String>(myKey), 'inner');
+        });
+        expect(api.Context.current.getValue<String>(myKey), 'outer');
+      });
+      expect(api.Context.current, same(api.Context.root));
+    });
   });
 }

--- a/test/api/context/context_test.dart
+++ b/test/api/context/context_test.dart
@@ -4,6 +4,7 @@
 @TestOn('vm')
 import 'dart:async';
 
+import 'package:logging/logging.dart' as logging;
 import 'package:opentelemetry/api.dart' as api;
 import 'package:opentelemetry/sdk.dart' as sdk;
 import 'package:opentelemetry/src/experimental_api.dart';
@@ -127,6 +128,86 @@ void main() {
           expect(api.Context.detach(token2), isTrue);
           expect(api.Context.detach(token1), isTrue);
         });
+      });
+    });
+  });
+
+  group('zoneValues-based propagation', () {
+    test('context propagated via zone() is visible to Context.current', () {
+      final myKey = api.ContextKey();
+      final ctx = api.Context.current.setValue(myKey, 'hello');
+      final observed = api
+          .zone(ctx)
+          .run(() => api.Context.current.getValue<String>(myKey));
+      expect(observed, 'hello');
+    });
+
+    test('runInContext makes the given context current', () {
+      final myKey = api.ContextKey();
+      final ctx = api.Context.current.setValue(myKey, 'world');
+      final observed = api.runInContext(
+        ctx,
+        () => api.Context.current.getValue<String>(myKey),
+      );
+      expect(observed, 'world');
+    });
+
+    test('zone().run does not leak per-microtask attaches', () async {
+      final myKey = api.ContextKey();
+      final ctx = api.Context.current.setValue(myKey, 'leak-check');
+      await api.zone(ctx).run(() async {
+        for (var i = 0; i < 50; i++) {
+          await Future.microtask(() {});
+          await Future<void>.delayed(Duration.zero);
+          expect(api.Context.current.getValue<String>(myKey), 'leak-check');
+        }
+      });
+      // After the zone exits, no stack-attached context should remain.
+      expect(api.Context.current, same(api.Context.root));
+    });
+
+    test(
+        'Future.whenComplete inside zone() does not trigger mismatched '
+        'detach warnings', () async {
+      final warnings = <String>[];
+      final sub = logging.Logger('opentelemetry')
+          .onRecord
+          .where((r) => r.level >= logging.Level.WARNING)
+          .listen((r) => warnings.add(r.message));
+      addTearDown(sub.cancel);
+
+      await api.zone(api.Context.root).run(() async {
+        await Future.microtask(() {});
+        await Future<void>.delayed(Duration.zero);
+        await Future.value(42).whenComplete(() async {
+          await Future.microtask(() {});
+        });
+      });
+      // Allow any deferred microtasks to flush.
+      await Future<void>.delayed(Duration.zero);
+      expect(warnings, isEmpty);
+    });
+
+    test('concurrent zone().run invocations do not interfere', () async {
+      final myKey = api.ContextKey();
+      final results = await Future.wait([
+        for (var i = 0; i < 100; i++)
+          api.zone(api.Context.current.setValue(myKey, i)).run(() async {
+            await Future<void>.delayed(const Duration(milliseconds: 1));
+            return api.Context.current.getValue<int>(myKey);
+          }),
+      ]);
+      expect(results, [for (var i = 0; i < 100; i++) i]);
+    });
+
+    test('zoneValues context wins over a same-zone attached context', () {
+      final myKey = api.ContextKey();
+      final zoneCtx = api.Context.current.setValue(myKey, 'zone');
+      api.runInContext(zoneCtx, () {
+        final attachedCtx = api.Context.current.setValue(myKey, 'attached');
+        final token = api.Context.attach(attachedCtx);
+        expect(api.Context.current.getValue<String>(myKey), 'zone');
+        api.Context.detach(token);
       });
     });
   });


### PR DESCRIPTION
# [FEA-11205](https://jira.atl.workiva.net/browse/FEA-11205)
![Issue Status](https://img.shields.io/endpoint?url=https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEA-11205)

## Which problem is this PR solving?

The `@experimental` `zone()` helper attached a `Context` on **every** `Zone.run(...)` invocation against the forked zone, not just on the user's explicit `zone(ctx).run(fn)` call.

The old implementation installed a `ZoneSpecification.run` hook that did `Context.attach(...)` / `Context.detach(...)` each time it fired. But the Dart SDK itself drives `zone.run(...)` for many internal operations against any non-root zone:

- `Future.whenComplete` callbacks (`_zone.run(_whenCompleteAction)`)
- `zone.bindCallback` results (microtasks/timers scheduled in non-root zones wrap via `bindCallback` / `bindCallbackGuarded`)
- `runGuarded(f)` (calls `run(f)` internally)

Every one of these re-entered the `run` hook and triggered another `Context.attach`. Consequences:

- Duplicate attaches per Dart-runtime-driven hop, bloating the per-zone `_stacks` entry.
- During the synchronous window of any re-entry the stack held `[outerToken, innerToken]`; if an outer `whenComplete`-registered detach fired in that window (or a `whenComplete` callback returned a `Future`, deferring its detach), the LIFO check tripped and emitted:
  ```
  opentelemetry: unexpected (mismatched) token given to detach
  ```
- Worst case (async `whenComplete`, or any unpaired `Context.attach`), tokens permanently accumulated and downstream detaches drifted further out of LIFO order — a steady stream of warnings.

## Short description of the change

Replace the `spec.run`-based attach/detach in `zone()` with **`zoneValues`-based propagation**.

- `zone()` now forks via `Zone.fork(zoneValues: {_contextZoneKey: context ?? _currentContext()})` — no more `ZoneSpecification.run` hook, no attach/detach ceremony around `zone.run(...)`. `zoneValues` lookups walk the zone tree with no `Zone.run` involvement, so they can't be re-fired by runtime-driven hops.
- `_currentContext` consults the zone value first, then falls back to the legacy `_stacks` walk. This is the only behavior change to existing public API: a `zoneValues`-propagated context is preferred over a stack-attached one in the same zone.
- New `@experimental runInContext<R>(Context, R Function())` convenience helper (`runZoned(body, zoneValues: {...})`), exported from `lib/api.dart`.
- The zone-value key (`_contextZoneKey`) is kept **private** — `zone()` and `runInContext()` are the full public surface; no raw key is exposed.
- `CHANGELOG.md` updated under `## Unreleased`.

### How this does NOT break existing consumption

- **Public API surface preserved.** `Context.attach`, `Context.detach`, `Context.current`, `contextWithSpan`, `spanFromContext`, etc. are unchanged. The `zone()` signature is still `Zone Function([Context?])` — existing `otel.zone(ctx).run(fn)` callers get improved runtime semantics (no duplicate attaches) with no call-shape change.
- **Legacy stack machinery intact.** The `_stacks` map and `_currentContextStack` walk remain as the fallback when no zone-value context is set, so existing direct `Context.attach` / `Context.detach` callers keep working exactly as before.
- **`Context.current` still resolves correctly** inside any region scoped by the new mechanism, so `tracer.startSpan(...)` (defaulting to `context: Context.current`) automatically picks up the correct parent.
- **No wire-format impact.** Change is purely Dart-internal context plumbing; no protobuf/serialization changes.
- **Only behavior delta (minor):** when a `zoneValues` context and a stack-attached context coexist in the same zone, the `zoneValues` context now wins (previously the stack-attached one won). `zoneValues` is the new canonical mechanism; no known Workiva caller depends on the old precedence.

## How Has This Been Tested?

- `dart analyze lib test` — no new errors/warnings (only pre-existing `info`-level notes).
- `dart test` — full suite passes, including existing `test/api/context/`, `test/api/open_telemetry_test.dart`, and `test/sdk/**` tests (unmodified).
- New tests added in `test/api/context/context_test.dart` demonstrating the fix:
  - context propagated via `zone()` / `runInContext` is visible to `Context.current`
  - `zone().run` does not leak per-microtask attaches (50 awaits, stack returns to root)
  - `Future.whenComplete` inside `zone()` produces no mismatched-detach warnings
  - 100 concurrent `zone().run` invocations stay isolated
  - `zoneValues` context wins over a same-zone attached context

## QA steps: compare the broken vs fixed example

Two branches carry an **identical** browser test bed under `web/` that runs `zone(ctx).run(() async { ... })` with async traffic (microtasks, timers, `Future.whenComplete`) and reports two things on the page and in the console:

- **PROPAGATION** — at every async checkpoint inside the zone, `Context.current` must still carry `ctx` (both its `ContextKey` value and its span context). Must be **PASS** on both branches.
- **EXCESS ATTACHES** — count of `unexpected (mismatched) token given to detach` warnings (the over-attach symptom).

The example uses only public API present on both branches (no new `runInContext` / key), so the *only* difference between the two runs is the `zone()` implementation.

**Prereqs:** Dart SDK ≥ 3.9, then `dart pub global activate webdev`.

### 1. First, reproduce the bad behavior (legacy `zone()`)

```sh
git fetch origin
git checkout repro/zone-detach-mismatch
dart pub get
webdev serve web:8088
```

Open http://127.0.0.1:8088 and open the browser devtools console. Expect:

- Page verdict: `PROPAGATION: PASS (6/6 checkpoints) | EXCESS ATTACHES: DETECTED (33 mismatched-token warnings)`
- Console: a flood of `[otel] unexpected (mismatched) token given to detach`, plus the marker `REPRO_RESULT propagation=PASS checkpoints=6/6 excessAttaches=DETECTED mismatchedDetachWarnings=33`

Takeaway: context still propagates correctly, but the legacy helper over-attaches and logs mismatched-detach warnings.

### 2. Then, confirm the fix (this PR's change, cherry-picked under the same example)

```sh
git checkout repro/fix-zone-detach-mismatch
dart pub get
webdev serve web:8088
```

Open http://127.0.0.1:8088 again. Expect:

- Page verdict: `PROPAGATION: PASS (6/6 checkpoints) | EXCESS ATTACHES: NONE (0 mismatched-token warnings)`
- Console: **no** detach warnings, plus the marker `REPRO_RESULT propagation=PASS checkpoints=6/6 excessAttaches=NONE mismatchedDetachWarnings=0`

Takeaway: with the fix in place propagation is unchanged (still PASS 6/6) and the excess attaches / warnings are gone.

> Note: `repro/fix-zone-detach-mismatch` = `repro/zone-detach-mismatch` + this PR's fix commit. The `web/` example is byte-for-byte identical between the two branches.

## Checklist:

- [x] Unit tests have been added
- [x] Documentation has been updated